### PR TITLE
Change Cloud Run concurrency and timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,8 +24,8 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL', # Directly use the substitution variable
     '--set-env-vars=PROJECT_ID=$PROJECT_ID',
-    '--containerConcurrency=1',
-    '--timeoutSeconds=3600'
+    '--concurrency=1',
+    '--timeout=3600'
   ]
 
 options:


### PR DESCRIPTION
- Change concurrency setting for Cloud Run from 320 (default) to 1
- Increase Cloud Run timeout from 360s (default) to 3600s (maximum)
- Closes [#50](https://github.com/Analyticsphere/ehr-pilot/issues/50)