### PR TITLE
Replace person_id with Connect_ID

### DIFF
--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -308,6 +308,7 @@ def get_normalization_sql_statement(gcs_file_path: str, cdm_version: str) -> str
     # --------------------------------------------------------------------------
     actual_columns = utils.get_columns_from_file(gcs_file_path)
 
+    # Get Connect_ID column name, if it exists
     connect_id_column_name = ""
     for column in actual_columns:
         if 'connectid' in column.lower() or 'connect_id' in column.lower():
@@ -334,7 +335,7 @@ def get_normalization_sql_statement(gcs_file_path: str, cdm_version: str) -> str
         row_hash_statement = ", ".join([f"COALESCE(CAST({field_name} AS VARCHAR), '')" for field_name in actual_columns])
 
         if field_name in actual_columns:
-            # If the site provided a Connect_ID field and person_id, use Connect_ID in place of person_id
+            # If the site provided a Connect_ID field and/or person_id, use Connect_ID in place of person_id
             if field_name == 'person_id' and connect_id_column_name and len(connect_id_column_name) > 1:
                 coalesce_exprs.append(f"CAST({connect_id_column_name} AS {field_type}) AS {field_name}")
             # If the column exists in the Parquet file, coalesce it with the default value, then try casting to expected type
@@ -352,7 +353,7 @@ def get_normalization_sql_statement(gcs_file_path: str, cdm_version: str) -> str
                 # ALL fields in a COALESCE must be of the same type, so casting everything to VARCHAR *after* trying to cast it to its correct type
                 row_validity.append(f"CAST(TRY_CAST(COALESCE({field_name}, {default_value}) AS {field_type}) AS VARCHAR)")
         else:
-            # If the site provided a Connect_ID field and person_id, use Connect_ID in place of person_id
+            # If the site provided a Connect_ID field and/or person_id, use Connect_ID in place of person_id
             if field_name == 'person_id' and connect_id_column_name and len(connect_id_column_name) > 1:
                 coalesce_exprs.append(f"CAST({connect_id_column_name} AS {field_type}) AS {field_name}")
 


### PR DESCRIPTION
- If a column "connect_id" or "connectid" is present in a file, use that column in place of person_id
- Closes issue [#66](https://github.com/Analyticsphere/ehr-pilot/issues/66)