### PR TITLE
Normalize some file encoding names

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+local-data/
+.git/
+.pytest_cache/
+.mypy_cache/
+__pycache__/
+*.pyc
+.DS_Store

--- a/core/utils.py
+++ b/core/utils.py
@@ -559,15 +559,15 @@ def get_csv_file_encoding(file_path: str) -> str:
 
         if encoding:
             encoding = encoding.lower()
-            
-            # Normalize UTF-8-family names to plain utf-8 after removing
-            # separators so variants like utf-8, utf_8, and utf_8_sig map
-            # cleanly to the encoding name DuckDB expects.
             normalized_encoding = encoding.replace('-', '').replace('_', '')
 
+            # Normalize UTF-8-family names to plain 'utf-8' encoding name that DuckDB expects
             if 'utf' in normalized_encoding and '8' in normalized_encoding:
                 encoding = 'utf-8'
-
+            # Normalize ISO-8859-x variants to 'latin-1' enconding name
+            elif normalized_encoding in {'iso88591', 'latin1'}:
+                encoding = 'latin-1'
+                
             logger.info(f"Detected encoding '{encoding}' (confidence: {result.get('confidence', 0):.2f}) for {file_path}")
             return encoding
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -559,6 +559,15 @@ def get_csv_file_encoding(file_path: str) -> str:
 
         if encoding:
             encoding = encoding.lower()
+            
+            # Normalize UTF-8-family names to plain utf-8 after removing
+            # separators so variants like utf-8, utf_8, and utf_8_sig map
+            # cleanly to the encoding name DuckDB expects.
+            normalized_encoding = encoding.replace('-', '').replace('_', '')
+
+            if 'utf' in normalized_encoding and '8' in normalized_encoding:
+                encoding = 'utf-8'
+
             logger.info(f"Detected encoding '{encoding}' (confidence: {result.get('confidence', 0):.2f}) for {file_path}")
             return encoding
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -714,3 +714,28 @@ def test_placeholder_to_harmonized_file_path_comprehensive(mock_datetime):
     )
 
     assert result == expected
+
+
+@pytest.mark.parametrize("detected_encoding", ["UTF-8-SIG", "utf_8_sig", "utf8", "UTF-8", "UTF_8", "utf__8--sig"])
+@patch('core.utils.fsspec.open')
+def test_get_csv_file_encoding_normalizes_utf8_family(mock_open, detected_encoding):
+    mock_file = MagicMock()
+    mock_file.read.return_value = b'\xef\xbb\xbfheader1,header2\nvalue1,value2\n'
+    mock_open.return_value.__enter__.return_value = mock_file
+
+    with patch('core.utils.chardet.detect', return_value={'encoding': detected_encoding, 'confidence': 1.0}):
+        result = utils.get_csv_file_encoding('file:///tmp/test.csv')
+
+    assert result == 'utf-8'
+
+
+@patch('core.utils.fsspec.open')
+def test_get_csv_file_encoding_preserves_utf16(mock_open):
+    mock_file = MagicMock()
+    mock_file.read.return_value = b'\xff\xfeh\x00e\x00a\x00d\x00e\x00r\x00'
+    mock_open.return_value.__enter__.return_value = mock_file
+
+    with patch('core.utils.chardet.detect', return_value={'encoding': 'UTF-16', 'confidence': 1.0}):
+        result = utils.get_csv_file_encoding('file:///tmp/test.csv')
+
+    assert result == 'utf-16'


### PR DESCRIPTION
- Normalize all UTF8 family of encodings to name `utf-8`, and all ISO-8859-x names to `latin-1`
- Add .dockerignore for improved performance when running locally