### PR TITLE
Convert NULL strings to NULL values

### DIFF
--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -213,6 +213,7 @@ class FileProcessor:
         select_list = []
 
         for column_name in parquet_columns:
+            # Quote column names to handle reserved keywords (i.e. offset); special characters should have been removed already
             quoted_column_name = '"' + column_name.replace('"', '""') + '"'
             select_list.append(
                 f"NULLIF(NULLIF({quoted_column_name}, 'NULL'), 'null') AS {quoted_column_name}"

--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -47,6 +47,7 @@ class FileProcessor:
         - Lowercase file name
         - Lowercase column names
         - VARCHAR column types
+        - Literal "NULL"/"null" string values converted to actual NULLs
         """
         if not utils.valid_parquet_file(self.file_path):
             raise Exception(f"Invalid Parquet file at {self.file_path}")
@@ -60,6 +61,7 @@ class FileProcessor:
             copy_sql,
             f"Unable to process incoming Parquet file {self.file_path}:"
         )
+        self.convert_parquet_string_nulls_to_null(self.output_path)
 
         return self.output_path
 
@@ -69,6 +71,7 @@ class FileProcessor:
 
         On first attempt, uses strict parsing settings.
         On failure, retries with permissive settings for malformed rows.
+        After conversion, rewrites literal "NULL"/"null" string values to actual NULLs.
 
         Args:
             retry: Whether this is a retry attempt
@@ -104,6 +107,7 @@ class FileProcessor:
             else:
                 raise
 
+        self.convert_parquet_string_nulls_to_null(self.output_path)
         return self.output_path
 
     @staticmethod
@@ -193,6 +197,42 @@ class FileProcessor:
         """
         
         return select_statement
+
+    @staticmethod
+    def convert_parquet_string_nulls_to_null(file_path: str) -> str:
+        """
+        Rewrite an all-string Parquet file so literal "NULL"/"null" values become actual NULLs.
+
+        Args:
+            file_path: Path to the all-string Parquet file to rewrite
+
+        Returns:
+            The original file path after in-place replacement
+        """
+        parquet_columns = utils.get_columns_from_file(file_path)
+        select_list = []
+
+        for column_name in parquet_columns:
+            quoted_column_name = '"' + column_name.replace('"', '""') + '"'
+            select_list.append(
+                f"NULLIF(NULLIF({quoted_column_name}, 'NULL'), 'null') AS {quoted_column_name}"
+            )
+
+        select_clause = ", ".join(select_list)
+        cleanup_sql = f"""
+        COPY (
+            SELECT {select_clause}
+            FROM read_parquet('{storage.get_uri(file_path)}')
+        )
+        TO '{storage.get_uri(file_path)}' {constants.DUCKDB_FORMAT_STRING}
+        """
+
+        utils.execute_duckdb_sql(
+            cleanup_sql,
+            f"Unable to convert string NULL values to NULL in Parquet file {file_path}"
+        )
+
+        return file_path
 
     @staticmethod
     def format_list(items: list) -> str:

--- a/tests/reference/sql/file_processor/convert_parquet_string_nulls_to_null_with_offset.sql
+++ b/tests/reference/sql/file_processor/convert_parquet_string_nulls_to_null_with_offset.sql
@@ -1,0 +1,7 @@
+
+        COPY (
+            SELECT NULLIF(NULLIF("note_nlp_id", 'NULL'), 'null') AS "note_nlp_id", NULLIF(NULLIF("offset", 'NULL'), 'null') AS "offset", NULLIF(NULLIF("lexical_variant", 'NULL'), 'null') AS "lexical_variant"
+            FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/note_nlp.parquet')
+        )
+        TO 'gs://synthea53/2025-01-01/artifacts/converted_files/note_nlp.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
+    

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -102,10 +102,11 @@ class TestFileProcessorProcess:
 class TestFileProcessorProcessParquet:
     """Tests for _process_parquet method."""
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
     @patch('core.file_processor.utils.valid_parquet_file')
-    def test_process_parquet_success(self, mock_valid, mock_get_columns, mock_execute):
+    def test_process_parquet_success(self, mock_valid, mock_get_columns, mock_execute, mock_cleanup):
         """Test successful Parquet file processing."""
         mock_valid.return_value = True
         mock_get_columns.return_value = ['person_id', 'gender_concept_id']
@@ -120,6 +121,7 @@ class TestFileProcessorProcessParquet:
         mock_valid.assert_called_once_with("bucket/2025-01-01/person.parquet")
         mock_get_columns.assert_called_once_with("bucket/2025-01-01/person.parquet")
         mock_execute.assert_called_once()
+        mock_cleanup.assert_called_once_with(processor.output_path)
         assert result == processor.output_path
 
     @patch('core.file_processor.utils.valid_parquet_file')
@@ -141,10 +143,11 @@ class TestFileProcessorProcessParquet:
 class TestFileProcessorProcessCSV:
     """Tests for _process_csv method."""
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.get_csv_file_encoding', return_value='utf-8')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
-    def test_process_csv_success_first_attempt(self, mock_get_columns, mock_execute, mock_encoding):
+    def test_process_csv_success_first_attempt(self, mock_get_columns, mock_execute, mock_encoding, mock_cleanup):
         """Test successful CSV conversion on first attempt."""
         mock_get_columns.return_value = ['person_id', 'gender_concept_id']
 
@@ -157,12 +160,14 @@ class TestFileProcessorProcessCSV:
 
         mock_get_columns.assert_called_once_with("bucket/2025-01-01/person.csv", encoding='utf-8')
         mock_execute.assert_called_once()
+        mock_cleanup.assert_called_once_with(processor.output_path)
         assert result == processor.output_path
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.get_csv_file_encoding', return_value='utf-8')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
-    def test_process_csv_retries_on_failure(self, mock_get_columns, mock_execute, mock_encoding):
+    def test_process_csv_retries_on_failure(self, mock_get_columns, mock_execute, mock_encoding, mock_cleanup):
         """Test that CSV conversion retries with permissive settings on failure."""
         mock_get_columns.return_value = ['person_id', 'gender_concept_id']
 
@@ -182,11 +187,13 @@ class TestFileProcessorProcessCSV:
         # Second call should have error handling options
         second_call_sql = mock_execute.call_args_list[1][0][0]
         assert "store_rejects=True" in second_call_sql or "ignore_errors=True" in second_call_sql
+        mock_cleanup.assert_called_once_with(processor.output_path)
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.get_csv_file_encoding', return_value='utf-8')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
-    def test_process_csv_raises_after_retry_fails(self, mock_get_columns, mock_execute, mock_encoding):
+    def test_process_csv_raises_after_retry_fails(self, mock_get_columns, mock_execute, mock_encoding, mock_cleanup):
         """Test that exception is raised if retry also fails."""
         mock_get_columns.return_value = ['person_id', 'gender_concept_id']
 
@@ -202,11 +209,13 @@ class TestFileProcessorProcessCSV:
             processor._process_csv()
 
         assert "Still failing" in str(exc_info.value)
+        mock_cleanup.assert_not_called()
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.get_csv_file_encoding', return_value='utf-8')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
-    def test_process_csv_with_conversion_options(self, mock_get_columns, mock_execute, mock_encoding):
+    def test_process_csv_with_conversion_options(self, mock_get_columns, mock_execute, mock_encoding, mock_cleanup):
         """Test CSV processing with explicit conversion options."""
         mock_get_columns.return_value = ['person_id', 'gender_concept_id']
 
@@ -220,6 +229,48 @@ class TestFileProcessorProcessCSV:
         # Check that SQL includes the option
         sql = mock_execute.call_args[0][0]
         assert "parallel=False" in sql
+        mock_cleanup.assert_called_once_with(processor.output_path)
+
+
+class TestFileProcessorNullStringCleanup:
+    """Tests for rewriting literal string null markers in Parquet files."""
+
+    @patch('core.file_processor.utils.get_columns_from_file')
+    @patch('core.file_processor.utils.execute_duckdb_sql')
+    def test_convert_parquet_string_nulls_to_null_success(
+        self, mock_execute, mock_get_columns
+    ):
+        """Test successful Parquet null-string cleanup."""
+        mock_get_columns.return_value = ['person_id', 'row_count']
+
+        result = FileProcessor.convert_parquet_string_nulls_to_null(
+            "bucket/2025-01-01/artifacts/converted_files/person.parquet"
+        )
+
+        mock_get_columns.assert_called_once_with(
+            "bucket/2025-01-01/artifacts/converted_files/person.parquet"
+        )
+        sql = mock_execute.call_args[0][0]
+        assert 'NULLIF(NULLIF("person_id", \'NULL\'), \'null\') AS "person_id"' in sql
+        assert 'NULLIF(NULLIF("row_count", \'NULL\'), \'null\') AS "row_count"' in sql
+        assert "TO 'gs://bucket/2025-01-01/artifacts/converted_files/person.parquet'" in sql
+        assert result == "bucket/2025-01-01/artifacts/converted_files/person.parquet"
+
+    @patch('core.file_processor.utils.get_columns_from_file')
+    @patch('core.file_processor.utils.execute_duckdb_sql')
+    def test_convert_parquet_string_nulls_to_null_quotes_offset_column(
+        self, mock_execute, mock_get_columns
+    ):
+        """Test reserved keyword columns like offset are quoted in cleanup SQL."""
+        mock_get_columns.return_value = ['note_nlp_id', 'offset', 'lexical_variant']
+
+        FileProcessor.convert_parquet_string_nulls_to_null(
+            "bucket/2025-01-01/artifacts/converted_files/note_nlp.parquet"
+        )
+
+        sql = mock_execute.call_args[0][0]
+        assert 'NULLIF(NULLIF("offset", \'NULL\'), \'null\') AS "offset"' in sql
+        assert 'NULLIF(NULLIF(offset, \'NULL\'), \'null\') AS offset' not in sql
 
 
 class TestFileProcessorStaticMethods:
@@ -293,10 +344,11 @@ class TestFileProcessorStaticMethods:
 class TestFileProcessorIntegration:
     """Integration tests for FileProcessor."""
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
     @patch('core.file_processor.utils.valid_parquet_file')
-    def test_full_parquet_processing_flow(self, mock_valid, mock_get_columns, mock_execute):
+    def test_full_parquet_processing_flow(self, mock_valid, mock_get_columns, mock_execute, mock_cleanup):
         """Test complete Parquet processing flow from initialization to completion."""
         mock_valid.return_value = True
         mock_get_columns.return_value = ['person_id', 'gender_concept_id', 'year_of_birth']
@@ -312,12 +364,14 @@ class TestFileProcessorIntegration:
         assert mock_valid.called
         assert mock_get_columns.called
         assert mock_execute.called
+        mock_cleanup.assert_called_once_with(processor.output_path)
         assert result == processor.output_path
 
+    @patch.object(FileProcessor, 'convert_parquet_string_nulls_to_null')
     @patch('core.file_processor.utils.get_csv_file_encoding', return_value='utf-8')
     @patch('core.file_processor.utils.execute_duckdb_sql')
     @patch('core.file_processor.utils.get_columns_from_file')
-    def test_full_csv_processing_flow_with_retry(self, mock_get_columns, mock_execute, mock_encoding):
+    def test_full_csv_processing_flow_with_retry(self, mock_get_columns, mock_execute, mock_encoding, mock_cleanup):
         """Test complete CSV processing flow with retry on failure."""
         mock_get_columns.return_value = ['person_id', 'gender_concept_id']
 
@@ -333,4 +387,5 @@ class TestFileProcessorIntegration:
 
         # Verify retry happened
         assert mock_execute.call_count == 2
+        mock_cleanup.assert_called_once_with(processor.output_path)
         assert result == processor.output_path

--- a/tests/test_file_processor_sql.py
+++ b/tests/test_file_processor_sql.py
@@ -7,6 +7,7 @@ in tests/reference/sql/file_processor/
 """
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -101,4 +102,22 @@ class TestGenerateCsvToParquetSql:
         )
 
         expected = load_reference_sql("generate_csv_to_parquet_sql_with_offset.sql")
+        assert normalize_sql(result) == normalize_sql(expected)
+
+
+class TestConvertParquetStringNullsToNullSql:
+    """Tests for SQL emitted by convert_parquet_string_nulls_to_null()."""
+
+    @patch('core.file_processor.utils.get_columns_from_file')
+    @patch('core.file_processor.utils.execute_duckdb_sql')
+    def test_with_offset_column(self, mock_execute, mock_get_columns):
+        """Test cleanup SQL generation with offset reserved keyword."""
+        mock_get_columns.return_value = ["note_nlp_id", "offset", "lexical_variant"]
+
+        FileProcessor.convert_parquet_string_nulls_to_null(
+            file_path="synthea53/2025-01-01/artifacts/converted_files/note_nlp.parquet"
+        )
+
+        result = mock_execute.call_args[0][0]
+        expected = load_reference_sql("convert_parquet_string_nulls_to_null_with_offset.sql")
         assert normalize_sql(result) == normalize_sql(expected)


### PR DESCRIPTION
- After processing incoming CSV/Parquet files, set "NULL" and "null" strings to `NULL` value in the 'all strings' Parquet file; last part of the `process_incoming_file` call