### PR TITLE
Fix Maps to value mapping

### DIFF
--- a/core/vocab_harmonization.py
+++ b/core/vocab_harmonization.py
@@ -811,8 +811,8 @@ class VocabHarmonizer:
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.{primary_key} = mv_cte.{primary_key}
                 WHERE (
-                    tbl.target_domain != 'Meas Value' AND
-                    tbl.mapping_relationship_id != 'Maps to value'
+                    IFNULL(tbl.target_domain, '') != 'Meas Value' AND
+                    IFNULL(tbl.mapping_relationship_id, '') != 'Maps to value'
                 )
             """
 
@@ -978,8 +978,8 @@ class VocabHarmonizer:
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.{primary_key_column} = mv_cte.{primary_key_column}
                 WHERE (
-                    tbl.target_domain != 'Meas Value' AND
-                    tbl.mapping_relationship_id != 'Maps to value'
+                    IFNULL(tbl.target_domain, '') != 'Meas Value' AND
+                    IFNULL(tbl.mapping_relationship_id, '') != 'Maps to value'
                 )
             """
 

--- a/core/vocab_harmonization.py
+++ b/core/vocab_harmonization.py
@@ -1065,7 +1065,7 @@ class VocabHarmonizer:
             f"{source_concept_id_column} AS source_concept_id",
             f"{target_concept_id_column} AS previous_target_concept_id",
             f"{target_concept_id_column} AS target_concept_id",
-            "vocab.relationship_id AS mapping_relationship_id"
+            #"vocab.relationship_id AS mapping_relationship_id"
         ]
 
         for metadata_column in metadata_columns:

--- a/core/vocab_harmonization.py
+++ b/core/vocab_harmonization.py
@@ -811,7 +811,7 @@ class VocabHarmonizer:
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.{primary_key} = mv_cte.{primary_key}
                 WHERE (
-                    tbl.target_domain != 'Meas Value' OR
+                    tbl.target_domain != 'Meas Value' AND
                     tbl.mapping_relationship_id != 'Maps to value'
                 )
             """
@@ -978,7 +978,7 @@ class VocabHarmonizer:
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.{primary_key_column} = mv_cte.{primary_key_column}
                 WHERE (
-                    tbl.target_domain != 'Meas Value' OR
+                    tbl.target_domain != 'Meas Value' AND
                     tbl.mapping_relationship_id != 'Maps to value'
                 )
             """

--- a/core/vocab_harmonization.py
+++ b/core/vocab_harmonization.py
@@ -748,8 +748,10 @@ class VocabHarmonizer:
             "'source_concept_id mapped to new target' AS vocab_harmonization_status",
             f"tbl.{source_concept_id_column} AS source_concept_id",
             f"tbl.{target_concept_id_column} AS previous_target_concept_id",
-            "vocab.target_concept_id AS target_concept_id"
+            "vocab.target_concept_id AS target_concept_id",
+            "vocab.relationship_id AS mapping_relationship_id"
         ]
+
         for metadata_column in metadata_columns:
             initial_select_exprs.append(metadata_column)
 
@@ -777,7 +779,10 @@ class VocabHarmonizer:
                 FROM read_parquet('@{source_table_name.upper()}') AS tbl
                 INNER JOIN read_parquet('@OPTIMIZED_VOCABULARY') AS vocab
                     ON tbl.{source_concept_id_column} = vocab.concept_id
-                WHERE vocab.target_concept_id_domain = 'Meas Value'
+                WHERE (
+                    vocab.target_concept_id_domain = 'Meas Value' OR
+                    vocab.relationship_id = 'Maps to value'
+                )
                 GROUP BY tbl.{primary_key}
             """
 
@@ -805,7 +810,10 @@ class VocabHarmonizer:
                 FROM base AS tbl
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.{primary_key} = mv_cte.{primary_key}
-                WHERE tbl.target_domain != 'Meas Value'
+                WHERE (
+                    tbl.target_domain != 'Meas Value' OR
+                    tbl.mapping_relationship_id != 'Maps to value'
+                )
             """
 
         cte_with_placeholders = f"""
@@ -905,8 +913,10 @@ class VocabHarmonizer:
             f"'{vocab_status_string}' AS vocab_harmonization_status",
             f"{source_concept_id_column} AS source_concept_id",
             f"tbl.{target_concept_id_column} AS previous_target_concept_id",
-            "vocab.target_concept_id AS target_concept_id"
+            "vocab.target_concept_id AS target_concept_id",
+            "vocab.relationship_id AS mapping_relationship_id"
         ]
+
         for metadata_column in metadata_columns:
             initial_select_exprs.append(metadata_column)
 
@@ -937,7 +947,9 @@ class VocabHarmonizer:
                 FROM read_parquet('@{source_table_name.upper()}') AS tbl
                 INNER JOIN read_parquet('@OPTIMIZED_VOCABULARY') AS vocab
                     ON tbl.{target_concept_id_column} = vocab.concept_id
-                WHERE vocab.target_concept_id_domain = 'Meas Value'
+                WHERE 
+                    (vocab.target_concept_id_domain = 'Meas Value' OR
+                    vocab.relationship_id = 'Maps to value')
                 GROUP BY tbl.{primary_key_column}
             """
 
@@ -965,7 +977,10 @@ class VocabHarmonizer:
                 FROM base AS tbl
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.{primary_key_column} = mv_cte.{primary_key_column}
-                WHERE tbl.target_domain != 'Meas Value'
+                WHERE (
+                    tbl.target_domain != 'Meas Value' OR
+                    tbl.mapping_relationship_id != 'Maps to value'
+                )
             """
 
         cte_with_placeholders = f"""
@@ -1049,8 +1064,10 @@ class VocabHarmonizer:
             "'domain check' AS vocab_harmonization_status",
             f"{source_concept_id_column} AS source_concept_id",
             f"{target_concept_id_column} AS previous_target_concept_id",
-            f"{target_concept_id_column} AS target_concept_id"
+            f"{target_concept_id_column} AS target_concept_id",
+            "vocab.relationship_id AS mapping_relationship_id"
         ]
+
         for metadata_column in metadata_columns:
             select_exprs.append(metadata_column)
 

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap.sql
@@ -23,7 +23,8 @@
                 'existing non-standard target remapped to standard code' AS vocab_harmonization_status,
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
-                vocab.target_concept_id AS target_concept_id
+                vocab.target_concept_id AS target_concept_id,
+                vocab.relationship_id AS mapping_relationship_id
                     
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
@@ -41,7 +42,9 @@
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
                     ON tbl.condition_concept_id = vocab.concept_id
-                WHERE vocab.target_concept_id_domain = 'Meas Value'
+                WHERE 
+                    (vocab.target_concept_id_domain = 'Meas Value' OR
+                    vocab.relationship_id = 'Maps to value')
                 GROUP BY tbl.condition_occurrence_id
             
                 )
@@ -67,6 +70,7 @@
                 source_concept_id,
                 previous_target_concept_id,
                 target_concept_id,
+                mapping_relationship_id,
                 mv_cte.vh_value_as_concept_id,
                 
                 CASE
@@ -85,7 +89,10 @@
                 FROM base AS tbl
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
-                WHERE tbl.target_domain != 'Meas Value'
+                WHERE (
+                    tbl.target_domain != 'Meas Value' OR
+                    tbl.mapping_relationship_id != 'Maps to value'
+                )
             
             
             ) TO 'synthea53/2025-01-01/artifacts/harmonized/condition_occurrence_target_remap.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap.sql
@@ -90,8 +90,8 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' AND
-                    tbl.mapping_relationship_id != 'Maps to value'
+                    IFNULL(tbl.target_domain, '') != 'Meas Value' AND
+                    IFNULL(tbl.mapping_relationship_id, '') != 'Maps to value'
                 )
             
             

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap.sql
@@ -90,7 +90,7 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' OR
+                    tbl.target_domain != 'Meas Value' AND
                     tbl.mapping_relationship_id != 'Maps to value'
                 )
             

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap_with_exclusion.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap_with_exclusion.sql
@@ -94,7 +94,7 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' OR
+                    tbl.target_domain != 'Meas Value' AND
                     tbl.mapping_relationship_id != 'Maps to value'
                 )
             

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap_with_exclusion.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap_with_exclusion.sql
@@ -94,8 +94,8 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' AND
-                    tbl.mapping_relationship_id != 'Maps to value'
+                    IFNULL(tbl.target_domain, '') != 'Meas Value' AND
+                    IFNULL(tbl.mapping_relationship_id, '') != 'Maps to value'
                 )
             
             

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap_with_exclusion.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_remap_with_exclusion.sql
@@ -23,7 +23,8 @@
                 'existing non-standard target remapped to standard code' AS vocab_harmonization_status,
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
-                vocab.target_concept_id AS target_concept_id
+                vocab.target_concept_id AS target_concept_id,
+                vocab.relationship_id AS mapping_relationship_id
                     
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
@@ -45,7 +46,9 @@
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
                     ON tbl.condition_concept_id = vocab.concept_id
-                WHERE vocab.target_concept_id_domain = 'Meas Value'
+                WHERE 
+                    (vocab.target_concept_id_domain = 'Meas Value' OR
+                    vocab.relationship_id = 'Maps to value')
                 GROUP BY tbl.condition_occurrence_id
             
                 )
@@ -71,6 +74,7 @@
                 source_concept_id,
                 previous_target_concept_id,
                 target_concept_id,
+                mapping_relationship_id,
                 mv_cte.vh_value_as_concept_id,
                 
                 CASE
@@ -89,7 +93,10 @@
                 FROM base AS tbl
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
-                WHERE tbl.target_domain != 'Meas Value'
+                WHERE (
+                    tbl.target_domain != 'Meas Value' OR
+                    tbl.mapping_relationship_id != 'Maps to value'
+                )
             
             
             ) TO 'synthea53/2025-01-01/artifacts/harmonized/condition_occurrence_target_remap.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_replacement.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_replacement.sql
@@ -23,7 +23,8 @@
                 'existing non-standard target replaced with standard code' AS vocab_harmonization_status,
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
-                vocab.target_concept_id AS target_concept_id
+                vocab.target_concept_id AS target_concept_id,
+                vocab.relationship_id AS mapping_relationship_id
                     
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
@@ -41,7 +42,9 @@
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
                     ON tbl.condition_concept_id = vocab.concept_id
-                WHERE vocab.target_concept_id_domain = 'Meas Value'
+                WHERE 
+                    (vocab.target_concept_id_domain = 'Meas Value' OR
+                    vocab.relationship_id = 'Maps to value')
                 GROUP BY tbl.condition_occurrence_id
             
                 )
@@ -67,6 +70,7 @@
                 source_concept_id,
                 previous_target_concept_id,
                 target_concept_id,
+                mapping_relationship_id,
                 mv_cte.vh_value_as_concept_id,
                 
                 CASE
@@ -85,7 +89,10 @@
                 FROM base AS tbl
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
-                WHERE tbl.target_domain != 'Meas Value'
+                WHERE (
+                    tbl.target_domain != 'Meas Value' OR
+                    tbl.mapping_relationship_id != 'Maps to value'
+                )
             
             
             ) TO 'synthea53/2025-01-01/artifacts/harmonized/condition_occurrence_target_replacement.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_replacement.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_replacement.sql
@@ -90,8 +90,8 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' AND
-                    tbl.mapping_relationship_id != 'Maps to value'
+                    IFNULL(tbl.target_domain, '') != 'Meas Value' AND
+                    IFNULL(tbl.mapping_relationship_id, '') != 'Maps to value'
                 )
             
             

--- a/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_replacement.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_check_new_targets_sql_target_replacement.sql
@@ -90,7 +90,7 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' OR
+                    tbl.target_domain != 'Meas Value' AND
                     tbl.mapping_relationship_id != 'Maps to value'
                 )
             

--- a/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_standard.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_standard.sql
@@ -1,6 +1,6 @@
 
             COPY (
-
+                
                     WITH vocab AS (
                         SELECT DISTINCT
                             concept_id,
@@ -28,8 +28,9 @@
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
                 tbl.condition_concept_id AS target_concept_id,
+                vocab.relationship_id AS mapping_relationship_id,
                 CAST(NULL AS BIGINT) AS vh_value_as_concept_id,
-
+                
                 CASE
                     WHEN vocab.concept_id_domain = 'Visit' THEN 'visit_occurrence'
                     WHEN vocab.concept_id_domain = 'Condition' THEN 'condition_occurrence'
@@ -42,13 +43,13 @@
                     WHEN vocab.concept_id_domain = 'Specimen' THEN 'specimen'
                     WHEN vocab.concept_id_domain IS NULL THEN 'condition_occurrence'
                 ELSE 'condition_occurrence' END AS target_table
-
-
+        
+                    
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 LEFT JOIN vocab
                     ON tbl.condition_concept_id = vocab.concept_id
-
-
-
+                
+                    
+                
             ) TO 'synthea53/2025-01-01/artifacts/harmonized/condition_occurrence_domain_check.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
-
+        

--- a/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_standard.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_standard.sql
@@ -28,7 +28,6 @@
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
                 tbl.condition_concept_id AS target_concept_id,
-                vocab.relationship_id AS mapping_relationship_id,
                 CAST(NULL AS BIGINT) AS vh_value_as_concept_id,
                 
                 CASE

--- a/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_with_exclusion.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_with_exclusion.sql
@@ -28,8 +28,9 @@
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
                 tbl.condition_concept_id AS target_concept_id,
+                vocab.relationship_id AS mapping_relationship_id,
                 CAST(NULL AS BIGINT) AS vh_value_as_concept_id,
-
+                
                 CASE
                     WHEN vocab.concept_id_domain = 'Visit' THEN 'visit_occurrence'
                     WHEN vocab.concept_id_domain = 'Condition' THEN 'condition_occurrence'
@@ -42,8 +43,8 @@
                     WHEN vocab.concept_id_domain = 'Specimen' THEN 'specimen'
                     WHEN vocab.concept_id_domain IS NULL THEN 'condition_occurrence'
                 ELSE 'condition_occurrence' END AS target_table
-
-
+        
+                    
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 LEFT JOIN vocab
                     ON tbl.condition_concept_id = vocab.concept_id

--- a/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_with_exclusion.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_domain_table_check_sql_with_exclusion.sql
@@ -28,7 +28,6 @@
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
                 tbl.condition_concept_id AS target_concept_id,
-                vocab.relationship_id AS mapping_relationship_id,
                 CAST(NULL AS BIGINT) AS vh_value_as_concept_id,
                 
                 CASE

--- a/tests/reference/sql/vocab_harmonization/generate_source_target_remapping_sql_standard.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_source_target_remapping_sql_standard.sql
@@ -92,7 +92,7 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' OR
+                    tbl.target_domain != 'Meas Value' AND
                     tbl.mapping_relationship_id != 'Maps to value'
                 )
             

--- a/tests/reference/sql/vocab_harmonization/generate_source_target_remapping_sql_standard.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_source_target_remapping_sql_standard.sql
@@ -23,7 +23,8 @@
                 'source_concept_id mapped to new target' AS vocab_harmonization_status,
                 tbl.condition_source_concept_id AS source_concept_id,
                 tbl.condition_concept_id AS previous_target_concept_id,
-                vocab.target_concept_id AS target_concept_id
+                vocab.target_concept_id AS target_concept_id,
+                vocab.relationship_id AS mapping_relationship_id
                     
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
@@ -42,7 +43,10 @@
                 FROM read_parquet('gs://synthea53/2025-01-01/artifacts/converted_files/condition_occurrence.parquet') AS tbl
                 INNER JOIN read_parquet('gs://vocabularies//v5.0_22-JAN-23/optimized/optimized_vocab_file.parquet') AS vocab
                     ON tbl.condition_source_concept_id = vocab.concept_id
-                WHERE vocab.target_concept_id_domain = 'Meas Value'
+                WHERE (
+                    vocab.target_concept_id_domain = 'Meas Value' OR
+                    vocab.relationship_id = 'Maps to value'
+                )
                 GROUP BY tbl.condition_occurrence_id
             
                 )
@@ -68,6 +72,7 @@
                 source_concept_id,
                 previous_target_concept_id,
                 target_concept_id,
+                mapping_relationship_id,
                 mv_cte.vh_value_as_concept_id,
                 
                 CASE
@@ -86,7 +91,10 @@
                 FROM base AS tbl
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
-                WHERE tbl.target_domain != 'Meas Value'
+                WHERE (
+                    tbl.target_domain != 'Meas Value' OR
+                    tbl.mapping_relationship_id != 'Maps to value'
+                )
             
             
             ) TO 'synthea53/2025-01-01/artifacts/harmonized/condition_occurrence_source_target_remap.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)

--- a/tests/reference/sql/vocab_harmonization/generate_source_target_remapping_sql_standard.sql
+++ b/tests/reference/sql/vocab_harmonization/generate_source_target_remapping_sql_standard.sql
@@ -92,8 +92,8 @@
                 LEFT JOIN meas_value AS mv_cte
                     ON tbl.condition_occurrence_id = mv_cte.condition_occurrence_id
                 WHERE (
-                    tbl.target_domain != 'Meas Value' AND
-                    tbl.mapping_relationship_id != 'Maps to value'
+                    IFNULL(tbl.target_domain, '') != 'Meas Value' AND
+                    IFNULL(tbl.mapping_relationship_id, '') != 'Maps to value'
                 )
             
             


### PR DESCRIPTION
- During vocab harmonization, fixed issue in which "Maps to value" concept ID mappings to codes outside of the 'Meas Value' domain would incorrectly create independent rows (in the table appropriate for the domain) instead of being associated with the "Maps to" concept in the value_as_concept_id field
- Update tests