### PR TITLE
Update get_connect_data endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ The endpoint details below are listed in the order each endpoint first appears i
 
 **DAG usage:** Called once per site delivery after file-level CDM upgrade and before file-level Connect filtering.
 
-**Description:** Exports Connect participant-status data from BigQuery into a Parquet artifact and creates Connect eligibility report artifacts.
+**Description:** Exports Connect participant-status data from BigQuery into a Parquet file. When `delivery_bucket` is provided, also creates Connect eligibility report artifacts.
 
 **Parameters:**
 
@@ -516,15 +516,18 @@ The endpoint details below are listed in the order each endpoint first appears i
 |-----------|------|----------|-------------|
 | `project_id` | string | Yes | BigQuery project ID |
 | `dataset_id` | string | Yes | BigQuery dataset containing the Connect participant table |
-| `delivery_bucket` | string | Yes | Delivery root path, for example `site/2024-01-15` |
-| `site_connect_id` | string or integer | Yes | Site-specific Connect identifier |
+| `delivery_bucket` | string | One of `delivery_bucket` or `parquet_destination` required | Delivery root path, for example `site/2024-01-15`. Used to infer the Parquet output location and to generate eligibility report artifacts. |
+| `parquet_destination` | string | One of `delivery_bucket` or `parquet_destination` required | Explicit output path for the Parquet file (must end in `.parquet`). Takes precedence over `delivery_bucket` for determining where to write. |
+| `site_connect_id` | string or integer | No | Site-specific Connect identifier. If omitted, data for all sites is returned. |
 
 **Notes:**
 
-- The exported Parquet file is written to `artifacts/connect_data/participant_status.parquet`.
-- A processed `person` Parquet artifact must already exist because the report-artifact step compares Connect identifiers to delivered `person_id` values.
+- At least one of `delivery_bucket` or `parquet_destination` must be provided. If both are given, `parquet_destination` determines the output path and `delivery_bucket` is used for report artifact generation.
+- When only `parquet_destination` is provided, eligibility report artifacts are not generated.
+- When only `delivery_bucket` is provided, the Parquet file is written to `artifacts/connect_data/participant_status.parquet` under the delivery path.
+- A processed `person` Parquet artifact must already exist when `delivery_bucket` is provided, because the report-artifact step compares Connect identifiers to delivered `person_id` values.
 
-**Example:**
+**Example (delivery bucket):**
 
 ```json
 {
@@ -532,6 +535,16 @@ The endpoint details below are listed in the order each endpoint first appears i
   "dataset_id": "connect_dataset",
   "delivery_bucket": "site/2024-01-15",
   "site_connect_id": "12345"
+}
+```
+
+**Example (explicit destination, all sites):**
+
+```json
+{
+  "project_id": "my-project",
+  "dataset_id": "connect_dataset",
+  "parquet_destination": "output-bucket/participant_status.parquet"
 }
 ```
 

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -218,13 +218,17 @@ def validate_file() -> tuple[str, int]:
 
 @app.route('/get_connect_data', methods=['POST'])
 def get_connect_data() -> tuple[str, int]:
-    """Get Connect study data for participants from BigQuery."""
+    """Create Parquet file containing information about Connect participant study status and data sharing elections."""
     data: dict[str, Any] = request.get_json() or {}
     project_id: Optional[str] = data.get('project_id')
     dataset_id: Optional[str] = data.get('dataset_id')
     delivery_bucket: Optional[str] = data.get('delivery_bucket')
-    site_connect_id: Optional[str] = data.get('site_connect_id')
-    missing_fields = _get_missing_fields(data, ['project_id', 'dataset_id', 'delivery_bucket', 'site_connect_id'])
+    parquet_destination: Optional[str] = data.get('parquet_destination')
+    site_connect_id: Optional[str] = data.get('site_connect_id') # optional; if blank, gets data for all sites
+
+    missing_fields = _get_missing_fields(data, ['project_id', 'dataset_id'])
+    if not delivery_bucket and not parquet_destination:
+        missing_fields.append('delivery_bucket or parquet_destination')
 
     # Validate required parameters
     if missing_fields:
@@ -233,10 +237,8 @@ def get_connect_data() -> tuple[str, int]:
     try:
         assert project_id is not None
         assert dataset_id is not None
-        assert delivery_bucket is not None
-        assert site_connect_id is not None
 
-        gcp_services.export_connect_data_to_parquet(project_id, dataset_id, delivery_bucket, site_connect_id)
+        gcp_services.export_connect_data_to_parquet(project_id, dataset_id, delivery_bucket, parquet_destination, site_connect_id)
         return "Retrieved Connect study data", 200
     except Exception as e:
         utils.logger.error(f"Unable to retrieve Connect study data: {str(e)}")

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -234,6 +234,9 @@ def get_connect_data() -> tuple[str, int]:
     if missing_fields:
         return _missing_fields_response(missing_fields)
 
+    if parquet_destination and not parquet_destination.endswith('.parquet'):
+        return "parquet_destination must end with '.parquet'", 400
+
     try:
         assert project_id is not None
         assert dataset_id is not None

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -224,7 +224,7 @@ def get_connect_data() -> tuple[str, int]:
     dataset_id: Optional[str] = data.get('dataset_id')
     delivery_bucket: Optional[str] = data.get('delivery_bucket')
     parquet_destination: Optional[str] = data.get('parquet_destination')
-    site_connect_id: Optional[str] = data.get('site_connect_id') # optional; if blank, gets data for all sites
+    site_connect_id: Optional[str] = data.get('site_connect_id')
 
     missing_fields = _get_missing_fields(data, ['project_id', 'dataset_id'])
     if not delivery_bucket and not parquet_destination:

--- a/core/gcp_services.py
+++ b/core/gcp_services.py
@@ -157,19 +157,33 @@ def write_query_results_to_parquet(
     utils.logger.info(f"Saved query results to {output_uri}")
     return output_uri
 
-def export_connect_data_to_parquet(project_id: str, dataset_id: str, delivery_bucket: str, site_connect_id: str) -> str:
-    """Build the Connect participant-status query and export the results to Parquet."""
+def build_connect_participant_status_sql(project_id: str, dataset_id: str, site_connect_id: Optional[str]) -> str:
+    """Build the Connect participant-status SQL query from template."""
     sql_path = os.path.join(constants.SQL_PATH, "connect_data", "participant_status.sql")
     with open(sql_path, 'r') as sql_file:
         sql_script = sql_file.read()
 
     sql_script = sql_script.replace("@PROJECT_ID", project_id)
     sql_script = sql_script.replace("@DATASET_ID", dataset_id)
-    # connect_id's are integers but are stored as strings in table
-    sql_script = sql_script.replace("@SITE_CONNECT_ID", str(site_connect_id)) 
 
-    bucket, delivery_date = utils.get_bucket_and_delivery_date_from_path(delivery_bucket)
-    output_path = utils.get_connect_data_path(bucket, delivery_date)
+    if site_connect_id:
+        sql_script = sql_script.replace("@SITE_FILTER", f"WHERE d_827220437 = '{site_connect_id}'")
+    else:
+        sql_script = sql_script.replace("@SITE_FILTER", "")
+
+    return sql_script
+
+
+def export_connect_data_to_parquet(project_id: str, dataset_id: str, delivery_bucket: Optional[str], parquet_destination: Optional[str], site_connect_id: Optional[str]) -> str:
+    """Build the Connect participant-status query and export the results to Parquet."""
+    sql_script = build_connect_participant_status_sql(project_id, dataset_id, site_connect_id)
+
+    if parquet_destination:
+        output_path = parquet_destination
+    else:
+        assert delivery_bucket is not None
+        bucket, delivery_date = utils.get_bucket_and_delivery_date_from_path(delivery_bucket)
+        output_path = utils.get_connect_data_path(bucket, delivery_date)
 
     output_uri = write_query_results_to_parquet(
         sql_script=sql_script,
@@ -177,7 +191,8 @@ def export_connect_data_to_parquet(project_id: str, dataset_id: str, delivery_bu
         project_id=project_id
     )
 
-    participant_filter.ParticipantFilter.create_connect_eligibility_report_artifacts(output_uri, delivery_bucket)
+    if delivery_bucket:
+        participant_filter.ParticipantFilter.create_connect_eligibility_report_artifacts(output_uri, delivery_bucket)
     return output_uri
 
 def list_gcs_subdirectories(gcs_path: str) -> list:

--- a/core/gcp_services.py
+++ b/core/gcp_services.py
@@ -158,7 +158,13 @@ def write_query_results_to_parquet(
     return output_uri
 
 def build_connect_participant_status_sql(project_id: str, dataset_id: str, site_connect_id: Optional[str]) -> str:
-    """Build the Connect participant-status SQL query from template."""
+    """Build the Connect participant-status SQL query from template.
+
+    Args:
+        project_id: GCP project ID containing the BigQuery dataset.
+        dataset_id: BigQuery dataset containing the Connect participants table.
+        site_connect_id: Connect site identifier to filter by. If None, returns data for all sites.
+    """
     sql_path = os.path.join(constants.SQL_PATH, "connect_data", "participant_status.sql")
     with open(sql_path, 'r') as sql_file:
         sql_script = sql_file.read()
@@ -175,7 +181,17 @@ def build_connect_participant_status_sql(project_id: str, dataset_id: str, site_
 
 
 def export_connect_data_to_parquet(project_id: str, dataset_id: str, delivery_bucket: Optional[str], parquet_destination: Optional[str], site_connect_id: Optional[str]) -> str:
-    """Build the Connect participant-status query and export the results to Parquet."""
+    """Build the Connect participant-status query and export the results to Parquet.
+
+    Args:
+        project_id: GCP project ID containing the BigQuery dataset.
+        dataset_id: BigQuery dataset containing the Connect participants table.
+        delivery_bucket: GCS path to the site delivery (e.g. 'bucket/2025-01-01'). Used to infer the
+            Parquet output location and to generate eligibility report artifacts.
+        parquet_destination: Explicit output path for the Parquet file. Takes precedence over
+            delivery_bucket for determining where to write.
+        site_connect_id: Connect site identifier to filter by. If None, returns data for all sites.
+    """
     sql_script = build_connect_participant_status_sql(project_id, dataset_id, site_connect_id)
 
     if parquet_destination:

--- a/tests/reference/sql/connect_data/participant_status_all_sites.sql
+++ b/tests/reference/sql/connect_data/participant_status_all_sites.sql
@@ -14,7 +14,20 @@ WITH status_map AS (
     d_821247024,
     d_747006172,
     d_773707518,
-    d_831041022
+    d_831041022,
+    d_659990606,
+    d_664453818,
+    d_269050420,
+    D_517311251,
+    D_832139544,
+    D_770257102,
+    d_264644252,
+    d_222161762,
+    d_764863765,
+    d_195145666,
+    d_217640691,
+    d_784810139,
+    d_199471989
   FROM `test-project.test_dataset.participants`
 
 ), cleaned_datapoints AS (
@@ -27,7 +40,20 @@ WITH status_map AS (
     CASE WHEN smap_hr.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_hr.concept_name END AS hipaa_revoked,
     d_773707518 AS hipaa_revoked_concept_id,
     CASE WHEN smap_dd.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_dd.concept_name END AS data_destruction_requested,
-    d_831041022 AS data_destruction_requested_concept_id
+    d_831041022 AS data_destruction_requested_concept_id,
+    d_659990606 AS consent_withdrawn_ts,
+    d_664453818 AS hipaa_revoked_ts,
+    d_269050420 AS data_destruction_ts,
+    D_517311251 AS module1_complete_ts,
+    D_832139544 AS module2_complete_ts,
+    D_770257102 AS module3_complete_ts,
+    d_264644252 AS module4_complete_ts,
+    d_222161762 AS bio_complete_ts,
+    d_764863765 AS clinicalbio_complete_ts,
+    d_195145666 AS mouthwash_complete_ts,
+    d_217640691 AS menstrual_complete_ts,
+    d_784810139 AS covid19_complete_ts,
+    d_199471989 AS experience2024_complete_ts
   FROM statuses s
   LEFT JOIN status_map smap_vs ON s.d_821247024 = smap_vs.concept_id
   LEFT JOIN status_map smap_cw ON s.d_747006172 = smap_cw.concept_id

--- a/tests/reference/sql/connect_data/participant_status_all_sites.sql
+++ b/tests/reference/sql/connect_data/participant_status_all_sites.sql
@@ -15,8 +15,8 @@ WITH status_map AS (
     d_747006172,
     d_773707518,
     d_831041022
-  FROM `@PROJECT_ID.@DATASET_ID.participants`
-  @SITE_FILTER
+  FROM `test-project.test_dataset.participants`
+
 ), cleaned_datapoints AS (
   SELECT DISTINCT
     Connect_ID,

--- a/tests/reference/sql/connect_data/participant_status_with_site_filter.sql
+++ b/tests/reference/sql/connect_data/participant_status_with_site_filter.sql
@@ -15,8 +15,8 @@ WITH status_map AS (
     d_747006172,
     d_773707518,
     d_831041022
-  FROM `@PROJECT_ID.@DATASET_ID.participants`
-  @SITE_FILTER
+  FROM `test-project.test_dataset.participants`
+  WHERE d_827220437 = '452456345'
 ), cleaned_datapoints AS (
   SELECT DISTINCT
     Connect_ID,

--- a/tests/reference/sql/connect_data/participant_status_with_site_filter.sql
+++ b/tests/reference/sql/connect_data/participant_status_with_site_filter.sql
@@ -14,7 +14,20 @@ WITH status_map AS (
     d_821247024,
     d_747006172,
     d_773707518,
-    d_831041022
+    d_831041022,
+    d_659990606,
+    d_664453818,
+    d_269050420,
+    D_517311251,
+    D_832139544,
+    D_770257102,
+    d_264644252,
+    d_222161762,
+    d_764863765,
+    d_195145666,
+    d_217640691,
+    d_784810139,
+    d_199471989
   FROM `test-project.test_dataset.participants`
   WHERE d_827220437 = '452456345'
 ), cleaned_datapoints AS (
@@ -27,7 +40,20 @@ WITH status_map AS (
     CASE WHEN smap_hr.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_hr.concept_name END AS hipaa_revoked,
     d_773707518 AS hipaa_revoked_concept_id,
     CASE WHEN smap_dd.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_dd.concept_name END AS data_destruction_requested,
-    d_831041022 AS data_destruction_requested_concept_id
+    d_831041022 AS data_destruction_requested_concept_id,
+    d_659990606 AS consent_withdrawn_ts,
+    d_664453818 AS hipaa_revoked_ts,
+    d_269050420 AS data_destruction_ts,
+    D_517311251 AS module1_complete_ts,
+    D_832139544 AS module2_complete_ts,
+    D_770257102 AS module3_complete_ts,
+    d_264644252 AS module4_complete_ts,
+    d_222161762 AS bio_complete_ts,
+    d_764863765 AS clinicalbio_complete_ts,
+    d_195145666 AS mouthwash_complete_ts,
+    d_217640691 AS menstrual_complete_ts,
+    d_784810139 AS covid19_complete_ts,
+    d_199471989 AS experience2024_complete_ts
   FROM statuses s
   LEFT JOIN status_map smap_vs ON s.d_821247024 = smap_vs.concept_id
   LEFT JOIN status_map smap_cw ON s.d_747006172 = smap_cw.concept_id

--- a/tests/test_connect_data_sql.py
+++ b/tests/test_connect_data_sql.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for Connect data SQL generation.
+
+Tests that the participant status SQL is correctly built with and without
+a site_connect_id filter. Reference SQL files are stored in
+tests/reference/sql/connect_data/
+"""
+
+from pathlib import Path
+
+from core.gcp_services import build_connect_participant_status_sql
+
+REFERENCE_DIR = Path(__file__).parent / "reference" / "sql" / "connect_data"
+
+
+def normalize_sql(sql: str) -> str:
+    lines = [line.strip() for line in sql.strip().split('\n')]
+    lines = [line for line in lines if line]
+    return '\n'.join(lines)
+
+
+def load_reference_sql(filename: str) -> str:
+    filepath = REFERENCE_DIR / filename
+    with open(filepath, 'r') as f:
+        return f.read()
+
+
+class TestBuildConnectParticipantStatusSql:
+    """Tests for build_connect_participant_status_sql()."""
+
+    def test_with_site_connect_id(self):
+        """Test SQL includes WHERE filter when site_connect_id is provided."""
+        result = build_connect_participant_status_sql(
+            project_id="test-project",
+            dataset_id="test_dataset",
+            site_connect_id="452456345"
+        )
+
+        expected = load_reference_sql("participant_status_with_site_filter.sql")
+        assert normalize_sql(result) == normalize_sql(expected)
+
+    def test_without_site_connect_id(self):
+        """Test SQL omits WHERE filter when site_connect_id is None."""
+        result = build_connect_participant_status_sql(
+            project_id="test-project",
+            dataset_id="test_dataset",
+            site_connect_id=None
+        )
+
+        expected = load_reference_sql("participant_status_all_sites.sql")
+        assert normalize_sql(result) == normalize_sql(expected)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -349,6 +349,89 @@ class TestUpgradeCdmEndpoint:
         assert b"Unable to upgrade file" in response.data
 
 
+class TestGetConnectDataEndpoint:
+    """Tests for /get_connect_data endpoint."""
+
+    @patch('core.endpoints.gcp_services.export_connect_data_to_parquet')
+    def test_get_connect_data_success_with_delivery_bucket(self, mock_export, client):
+        """Test successful retrieval with delivery_bucket."""
+        response = client.post('/get_connect_data', json={
+            'project_id': 'test-project',
+            'dataset_id': 'test_dataset',
+            'delivery_bucket': 'test-bucket/2025-01-01',
+            'site_connect_id': '123456'
+        })
+
+        assert response.status_code == 200
+        assert b"Retrieved Connect study data" in response.data
+        mock_export.assert_called_once_with(
+            'test-project', 'test_dataset', 'test-bucket/2025-01-01', None, '123456'
+        )
+
+    @patch('core.endpoints.gcp_services.export_connect_data_to_parquet')
+    def test_get_connect_data_success_with_parquet_destination(self, mock_export, client):
+        """Test successful retrieval with parquet_destination instead of delivery_bucket."""
+        response = client.post('/get_connect_data', json={
+            'project_id': 'test-project',
+            'dataset_id': 'test_dataset',
+            'parquet_destination': 'gs://output-bucket/connect/status.parquet',
+            'site_connect_id': '123456'
+        })
+
+        assert response.status_code == 200
+        assert b"Retrieved Connect study data" in response.data
+        mock_export.assert_called_once_with(
+            'test-project', 'test_dataset', None, 'gs://output-bucket/connect/status.parquet', '123456'
+        )
+
+    @patch('core.endpoints.gcp_services.export_connect_data_to_parquet')
+    def test_get_connect_data_success_without_site_connect_id(self, mock_export, client):
+        """Test successful retrieval without site_connect_id returns all sites."""
+        response = client.post('/get_connect_data', json={
+            'project_id': 'test-project',
+            'dataset_id': 'test_dataset',
+            'delivery_bucket': 'test-bucket/2025-01-01'
+        })
+
+        assert response.status_code == 200
+        mock_export.assert_called_once_with(
+            'test-project', 'test_dataset', 'test-bucket/2025-01-01', None, None
+        )
+
+    def test_get_connect_data_missing_project_and_dataset(self, client):
+        """Test missing project_id and dataset_id returns 400."""
+        response = client.post('/get_connect_data', json={
+            'delivery_bucket': 'test-bucket/2025-01-01'
+        })
+
+        assert_missing_fields(response, 'project_id', 'dataset_id')
+
+    def test_get_connect_data_missing_bucket_and_destination(self, client):
+        """Test missing both delivery_bucket and parquet_destination returns 400."""
+        response = client.post('/get_connect_data', json={
+            'project_id': 'test-project',
+            'dataset_id': 'test_dataset'
+        })
+
+        assert response.status_code == 400
+        assert b"delivery_bucket or parquet_destination" in response.data
+
+    @patch('core.endpoints.gcp_services.export_connect_data_to_parquet')
+    def test_get_connect_data_exception(self, mock_export, client):
+        """Test exception handling returns 500."""
+        mock_export.side_effect = Exception("BigQuery error")
+
+        response = client.post('/get_connect_data', json={
+            'project_id': 'test-project',
+            'dataset_id': 'test_dataset',
+            'delivery_bucket': 'test-bucket/2025-01-01',
+            'site_connect_id': '123456'
+        })
+
+        assert response.status_code == 500
+        assert b"Unable to retrieve Connect study data" in response.data
+
+
 class TestFilterConnectParticipantsEndpoint:
     """Tests for /filter_connect_participants endpoint."""
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -406,6 +406,17 @@ class TestGetConnectDataEndpoint:
 
         assert_missing_fields(response, 'project_id', 'dataset_id')
 
+    def test_get_connect_data_invalid_parquet_destination(self, client):
+        """Test parquet_destination not ending in .parquet returns 400."""
+        response = client.post('/get_connect_data', json={
+            'project_id': 'test-project',
+            'dataset_id': 'test_dataset',
+            'parquet_destination': 'some-bucket/no_extension'
+        })
+
+        assert response.status_code == 400
+        assert b"parquet_destination must end with '.parquet'" in response.data
+
     def test_get_connect_data_missing_bucket_and_destination(self, client):
         """Test missing both delivery_bucket and parquet_destination returns 400."""
         response = client.post('/get_connect_data', json={


### PR DESCRIPTION
- Add an optional `parquet_destination` parameter to the `get_connect_data` endpoint. When provided, the participant status parquet file will be written to the specified path; otherwise, it will default to the existing `artifacts/connect_data` location
- Update `get_connect_data` behavior so that when `site_connect_id` is omitted, the endpoint returns data for all sites instead of requiring a specific site.
- Update and add tests to cover new behavior