### PR TITLE
Performance improvements

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,12 +20,12 @@ steps:
   args: [
     'run', 'deploy', '$_IMAGE_NAME',
     '--image=gcr.io/$PROJECT_ID/$_IMAGE_NAME:$COMMIT_SHA',
-    '--cpu=4', '--memory=16Gi',
+    '--cpu=$_DEFAULT_CPU', '--memory=$_DEFAULT_MEMORY',
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL', # Directly use the substitution variable
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
     '--concurrency=1',
-    '--timeout=3600s',
+    '--timeout=$_SERVICE_TIMEOUT',
     '--execution-environment=gen2',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
     '--add-volume-mount=volume=duckdb_files,mount-path=/mnt/data'
@@ -40,9 +40,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -59,9 +59,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -78,9 +78,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -97,9 +97,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -116,9 +116,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=7200s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_HARMONIZE_VOCAB_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -135,9 +135,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -154,9 +154,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -173,9 +173,9 @@ steps:
     '--region=us-central1',
     '--service-account=$SERVICE_ACCOUNT_EMAIL',
     '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
-    '--cpu=4',
-    '--memory=16Gi',
-    '--task-timeout=3600s',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_DEFAULT_TASK_TIMEOUT',
     '--max-retries=0',
     '--parallelism=1',
     '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
@@ -185,6 +185,17 @@ steps:
 
 options:
   logging: CLOUD_LOGGING_ONLY
+
+# Default Cloud Run resource allocations applied across the service and all jobs.
+# Override per-trigger or per-deployment by setting the corresponding substitution.
+# Per-job overrides live inline above (e.g. _HARMONIZE_VOCAB_TIMEOUT for the
+# harmonize-vocab job, which needs more headroom than the other jobs).
+substitutions:
+  _DEFAULT_CPU: '4'
+  _DEFAULT_MEMORY: '16Gi'
+  _DEFAULT_TASK_TIMEOUT: '3600s'
+  _SERVICE_TIMEOUT: '3600s'
+  _HARMONIZE_VOCAB_TIMEOUT: '7200s'
 
 images:
   - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:$COMMIT_SHA'

--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -93,7 +93,8 @@ class FileProcessor:
         try:
             utils.execute_duckdb_sql(
                 convert_statement,
-                f"Unable to convert CSV file to Parquet {storage.get_uri(self.file_path)}"
+                f"Unable to convert CSV file to Parquet {storage.get_uri(self.file_path)}",
+                load_encodings=True
             )
         except Exception as e:
             if not retry:

--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -103,7 +103,7 @@ class FileProcessor:
 
                 return self._process_csv(
                     retry=True,
-                    conversion_options=["store_rejects=True, ignore_errors=True, parallel=False"]
+                    conversion_options=["store_rejects=True, ignore_errors=True, parallel=False, strict_mode=False"]
                 )
             else:
                 raise
@@ -193,7 +193,7 @@ class FileProcessor:
         COPY (
             SELECT {select_clause}
             FROM read_csv('{storage.get_uri(file_path)}',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False {FileProcessor.format_list(conversion_options)})
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True {FileProcessor.format_list(conversion_options)})
         ) TO '{storage.get_uri(parquet_path)}' {constants.DUCKDB_FORMAT_STRING}
         """
         

--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -84,9 +84,10 @@ class FileProcessor:
         # Get column names from CSV using detected encoding
         csv_column_names = utils.get_columns_from_file(self.file_path, encoding=encoding)
 
-        # Generate SQL — always include detected encoding
+        # Generate SQL — always include detected encoding; retries disable strict_mode
         convert_statement = self.generate_csv_to_parquet_sql(
-            self.file_path, csv_column_names, [f"encoding='{encoding}'"] + conversion_options
+            self.file_path, csv_column_names, [f"encoding='{encoding}'"] + conversion_options,
+            strict_mode=not retry,
         )
 
         # Execute SQL with retry logic
@@ -103,7 +104,7 @@ class FileProcessor:
 
                 return self._process_csv(
                     retry=True,
-                    conversion_options=["store_rejects=True, ignore_errors=True, parallel=False, strict_mode=False"]
+                    conversion_options=["store_rejects=True, ignore_errors=True, parallel=False"]
                 )
             else:
                 raise
@@ -151,7 +152,7 @@ class FileProcessor:
         return select_statement
 
     @staticmethod
-    def generate_csv_to_parquet_sql(file_path: str, csv_column_names: list[str], conversion_options: list = []) -> str:
+    def generate_csv_to_parquet_sql(file_path: str, csv_column_names: list[str], conversion_options: list = [], strict_mode: bool = True) -> str:
         """
         Generate SQL to convert CSV file to Parquet format.
 
@@ -193,7 +194,7 @@ class FileProcessor:
         COPY (
             SELECT {select_clause}
             FROM read_csv('{storage.get_uri(file_path)}',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=True {FileProcessor.format_list(conversion_options)})
+                null_padding=True, ALL_VARCHAR=True, strict_mode={strict_mode} {FileProcessor.format_list(conversion_options)})
         ) TO '{storage.get_uri(parquet_path)}' {constants.DUCKDB_FORMAT_STRING}
         """
         

--- a/core/utils.py
+++ b/core/utils.py
@@ -28,10 +28,17 @@ logging.basicConfig(
 # Create the logger at module level so its settings are applied throughout code base
 logger = logging.getLogger(__name__)
 
-def create_duckdb_connection() -> tuple[duckdb.DuckDBPyConnection, str]:
+def create_duckdb_connection(load_encodings: bool = False) -> tuple[duckdb.DuckDBPyConnection, str]:
     """
     Create DuckDB connection with optimized settings for processing OMOP files.
     Configures memory limits, threading, and filesystem support.
+
+    Args:
+        load_encodings: If True, install and load the DuckDB `encodings` extension
+            (needed to read CSV files in encodings beyond DuckDB's built-in set).
+            Defaults to False because the extension is only needed during
+            CSV-to-Parquet conversion paths; all other connections operate on
+            Parquet files and don't benefit from loading it.
     """
     try:
         random_string = str(uuid.uuid4())
@@ -59,8 +66,9 @@ def create_duckdb_connection() -> tuple[duckdb.DuckDBPyConnection, str]:
         # Set max size to allow on disk
         conn.execute(f"SET max_temp_directory_size='{constants.DUCKDB_MAX_SIZE}'")
 
-        # Install encodings extension to handle 1000+ CSV encodings
-        conn.execute("INSTALL encodings; LOAD encodings")
+        if load_encodings:
+            # Install encodings extension to handle 1000+ CSV encodings
+            conn.execute("INSTALL encodings; LOAD encodings")
 
         # Register filesystem for cloud storage if using GCS backend
         if constants.STORAGE_BACKEND == constants.GCS_BACKEND:
@@ -89,7 +97,7 @@ def close_duckdb_connection(conn: duckdb.DuckDBPyConnection, local_db_file: Opti
         # Manually run garabage collection here to reclaim memory
         gc.collect()
 
-def execute_duckdb_sql(sql: str, error_msg: str, return_results: bool = False):
+def execute_duckdb_sql(sql: str, error_msg: str, return_results: bool = False, load_encodings: bool = False):
     """
     Execute SQL statement using DuckDB with automatic connection management.
 
@@ -97,6 +105,9 @@ def execute_duckdb_sql(sql: str, error_msg: str, return_results: bool = False):
         sql: SQL statement to execute
         error_msg: Error message to display if execution fails
         return_results: If True, returns all query results as a list. If False, returns None. Defaults to False.
+        load_encodings: If True, install/load the DuckDB `encodings` extension on the
+            connection. Set this only when the SQL reads a CSV that may use a non-default
+            encoding (i.e. CSV-to-Parquet conversion paths).
 
     Returns:
         If return_results=True: List of result rows from the query
@@ -106,7 +117,7 @@ def execute_duckdb_sql(sql: str, error_msg: str, return_results: bool = False):
     local_db_file = None
 
     try:
-        conn, local_db_file = create_duckdb_connection()
+        conn, local_db_file = create_duckdb_connection(load_encodings=load_encodings)
 
         with conn:
             result = conn.execute(sql)
@@ -202,7 +213,7 @@ def get_columns_from_file(file_path: str, encoding: str = 'utf-8') -> list:
     conn = None
     local_db_file = None
     try:
-        conn, local_db_file = create_duckdb_connection()
+        conn, local_db_file = create_duckdb_connection(load_encodings=is_csv)
         with conn:
             # Drop any existing temp table with the same name
             conn.execute(f"DROP TABLE IF EXISTS {table_name_for_introspection}")

--- a/core/utils.py
+++ b/core/utils.py
@@ -225,7 +225,7 @@ def get_columns_from_file(file_path: str, encoding: str = 'utf-8') -> list:
                     SELECT * FROM read_csv('{storage.get_uri(file_path)}',
                                           null_padding=True,
                                           ALL_VARCHAR=True,
-                                          strict_mode=False,
+                                          strict_mode=True,
                                           ignore_errors=True,
                                           encoding='{encoding}')
                     LIMIT 0

--- a/core/vocab_manager.py
+++ b/core/vocab_manager.py
@@ -55,7 +55,11 @@ class VocabularyManager:
                 convert_query = self.generate_convert_vocab_sql(csv_file_path, parquet_file_path, csv_columns)
 
                 # Execute SQL
-                utils.execute_duckdb_sql(convert_query, "Unable to convert vocabulary CSV to Parquet")
+                utils.execute_duckdb_sql(
+                    convert_query,
+                    "Unable to convert vocabulary CSV to Parquet",
+                    load_encodings=True
+                )
 
     def create_optimized_vocab_file(self) -> None:
         """

--- a/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_no_options.sql
+++ b/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_no_options.sql
@@ -6,6 +6,6 @@
                 "gender_concept_id" AS gender_concept_id
                 
             FROM read_csv('gs://bucket/2025-01-01/person.csv',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False )
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True )
         ) TO 'gs://bucket/2025-01-01/artifacts/converted_files/person.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
         

--- a/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_standard_no_options.sql
+++ b/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_standard_no_options.sql
@@ -10,6 +10,6 @@
                 "birth_datetime" AS birth_datetime
             
             FROM read_csv('gs://synthea53/2025-01-01/person.csv',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False )
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True )
         ) TO 'gs://synthea53/2025-01-01/artifacts/converted_files/person.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
     

--- a/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_offset.sql
+++ b/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_offset.sql
@@ -8,6 +8,6 @@
                 "lexical_variant" AS lexical_variant
             
             FROM read_csv('gs://synthea53/2025-01-01/note_nlp.csv',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False )
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True )
         ) TO 'gs://synthea53/2025-01-01/artifacts/converted_files/note_nlp.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
     

--- a/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_options.sql
+++ b/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_options.sql
@@ -10,6 +10,6 @@
                 "measurement_date" AS measurement_date
             
             FROM read_csv('gs://synthea53/2025-01-01/measurement.csv',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False ,store_rejects=True, ignore_errors=True, parallel=False)
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True ,store_rejects=True, ignore_errors=True, parallel=False)
         ) TO 'gs://synthea53/2025-01-01/artifacts/converted_files/measurement.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
     

--- a/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_parallel_false.sql
+++ b/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_parallel_false.sql
@@ -6,6 +6,6 @@
                 "gender_concept_id" AS gender_concept_id
                 
             FROM read_csv('gs://bucket/2025-01-01/person.csv',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False ,encoding='utf-8', parallel=False)
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True ,encoding='utf-8', parallel=False)
         ) TO 'gs://bucket/2025-01-01/artifacts/converted_files/person.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
         

--- a/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_string_options.sql
+++ b/tests/reference/sql/file_processor/generate_csv_to_parquet_sql_with_string_options.sql
@@ -6,6 +6,6 @@
                 "gender_concept_id" AS gender_concept_id
                 
             FROM read_csv('gs://bucket/2025-01-01/person.csv',
-                null_padding=True, ALL_VARCHAR=True, strict_mode=False ,store_rejects=True, ignore_errors=True)
+                null_padding=True, ALL_VARCHAR=True, strict_mode=True ,store_rejects=True, ignore_errors=True)
         ) TO 'gs://bucket/2025-01-01/artifacts/converted_files/person.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
         


### PR DESCRIPTION
- Only install DuckDB `encodings` extension when reading CSV files
- Set `strict_mode=True` by default when reading CSV files
- Replace hard-coded resource limits in `cloudbuild.yaml` with constants