### PR TITLE
Add person table to natural key globalization process

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,8 @@ The endpoint details below are listed in the order each endpoint first appears i
 
 **Notes:**
 
-- Vocabulary tables and `person` are excluded by policy (`NATURAL_KEY_REWRITE_SKIP_TABLES`). The endpoint returns a 200 success with a skip message in those cases.
+- Vocabulary tables are excluded by policy (`NATURAL_KEY_REWRITE_SKIP_TABLES`). The endpoint returns a 200 success with a skip message in those cases.
+- The `person` table IS rewritten — its `location_id`, `provider_id`, and `care_site_id` FK columns are globalized so they continue to reference the rewritten parent rows. `person_id` is protected from rewrite by its exclusion from `GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS`, which holds across every table where `person_id` appears.
 - Tables with none of the in-scope columns present are also skipped with a 200 success.
 - Columns rewritten when present (`GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS`):
     - `visit_occurrence_id`, `preceding_visit_occurrence_id`

--- a/README.md
+++ b/README.md
@@ -800,26 +800,28 @@ The endpoint details below are listed in the order each endpoint first appears i
 | `dataset_id` | string | Yes | BigQuery dataset ID |
 | `step` | string | Yes | Harmonization step name |
 
-**Step order in the DAG:**
+**Defined harmonization steps:**
 
-| Order | `step` value | Execution model |
-|------|--------------|-----------------|
-| 1 | `source_target` | Per eligible file |
-| 2 | `target_remap` | Per eligible file |
-| 3 | `target_replacement` | Per eligible file |
-| 4 | `source_concept_backfill` | Per eligible file |
-| 5 | `domain_check` | Per eligible file |
-| 6 | `secondary_concept_backfill` | Per eligible file |
-| 7 | `omop_etl` | Per eligible file |
-| 8 | `consolidate_etl` | Once per site |
-| 9 | `discover_tables_for_dedup` | Once per site |
-| 10 | `deduplicate_single_table` | Once per discovered table |
+The table below lists every step the endpoint accepts. Two steps (marked *not in DAG*) remain available as endpoints but are intentionally excluded from the current DAG chain — see the [Typical Pipeline Order](#typical-pipeline-order) for the active execution order.
+
+| `step` value | Execution model | DAG status |
+|--------------|-----------------|------------|
+| `source_target` | Per eligible file | Active |
+| `target_remap` | Per eligible file | Active |
+| `target_replacement` | Per eligible file | **Not in DAG** |
+| `source_concept_backfill` | Per eligible file | Active |
+| `domain_check` | Per eligible file | Active |
+| `secondary_concept_backfill` | Per eligible file | **Not in DAG** |
+| `omop_etl` | Per eligible file | Active |
+| `consolidate_etl` | Once per site | Active |
+| `discover_tables_for_dedup` | Once per site | Active |
+| `deduplicate_single_table` | Once per discovered table | Active |
 
 **Notes:**
 
 - The orchestrator skips tables outside the harmonized-table set before calling the endpoint.
 - `source_concept_backfill` sets the primary `_concept_id` to `_source_concept_id` when the concept ID is zero, the source concept ID is non-zero, and the source concept exists in the vocabulary.
-- `secondary_concept_backfill` applies the same backfill logic to non-primary concept ID columns (e.g., `unit_concept_id`) across all harmonized files produced by prior steps.
+- `secondary_concept_backfill` applies the same backfill logic to non-primary concept ID columns (e.g., `unit_concept_id`) across all harmonized files produced by prior steps. Even though this step is not invoked by the current DAG, the endpoint still accepts it.
 - `discover_tables_for_dedup` returns `table_configs` in the response.
 - For `deduplicate_single_table`, the `file_path` field must contain the JSON-encoded configuration returned by the discovery step.
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -603,4 +603,8 @@ GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS = [
 ]
 
 # Tables that are not rewritten by the natural-key globalization step.
-NATURAL_KEY_REWRITE_SKIP_TABLES = VOCABULARY_TABLES + ["person"]
+# person is NOT skipped: it has location_id/provider_id/care_site_id FK columns
+# that must be globalized so they continue to reference rewritten parent rows.
+# person_id is protected by exclusion from GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS,
+# not by skipping the table.
+NATURAL_KEY_REWRITE_SKIP_TABLES = VOCABULARY_TABLES

--- a/tests/test_natural_keys.py
+++ b/tests/test_natural_keys.py
@@ -46,7 +46,7 @@ class TestNaturalKeyProcessorInit:
 class TestNaturalKeyProcessorApply:
     """Tests for the apply() orchestration method."""
 
-    @pytest.mark.parametrize("table_name", ["person", "concept", "vocabulary", "domain"])
+    @pytest.mark.parametrize("table_name", ["concept", "vocabulary", "domain"])
     @patch('core.natural_keys.utils.execute_duckdb_sql')
     @patch('core.natural_keys.utils.parquet_file_exists')
     def test_skips_excluded_tables(self, mock_exists, mock_execute, table_name):
@@ -140,13 +140,55 @@ class TestNaturalKeyProcessorApply:
         assert "condition_occurrence_id IS NOT NULL" not in executed_sql
 
 
+    @patch('core.natural_keys.storage.get_uri')
+    @patch('core.natural_keys.utils.execute_duckdb_sql')
+    @patch('core.natural_keys.utils.get_columns_from_file')
+    @patch('core.natural_keys.utils.parquet_file_exists')
+    def test_rewrites_person_fk_columns_but_not_person_id(
+        self, mock_exists, mock_get_columns, mock_execute, mock_get_uri
+    ):
+        """person table must be rewritten on its FK columns (location_id,
+        provider_id, care_site_id) while person_id is left untouched."""
+        mock_exists.return_value = True
+        mock_get_columns.return_value = [
+            "person_id",  # never rewritten
+            "gender_concept_id",  # vocab ref, not rewritten
+            "location_id",  # rewritten
+            "provider_id",  # rewritten
+            "care_site_id",  # rewritten
+        ]
+        mock_get_uri.side_effect = lambda path: f"gs://{path}"
+
+        processor = NaturalKeyProcessor(
+            file_path="test-bucket/2025-01-15/person.parquet",
+            cdm_version="5.4",
+            site="site_alpha",
+        )
+
+        result = processor.apply()
+
+        assert result is True
+        mock_execute.assert_called_once()
+
+        executed_sql = mock_execute.call_args[0][0]
+        assert "location_id" in executed_sql
+        assert "provider_id" in executed_sql
+        assert "care_site_id" in executed_sql
+        assert "'site_alpha'" in executed_sql
+        # person_id must NOT appear as a rewritten column
+        assert "person_id IS NOT NULL" not in executed_sql
+
+
 class TestSkipTablesConstant:
     """Sanity tests on the constants — defensive checks against accidental
     rule violations in future refactors."""
 
-    def test_person_is_skipped(self):
-        """person must always be in the skip list (project rule)."""
-        assert "person" in constants.NATURAL_KEY_REWRITE_SKIP_TABLES
+    def test_person_is_not_skipped(self):
+        """person must NOT be in the skip list — its location_id, provider_id,
+        and care_site_id FK columns need to be globalized so they keep
+        referencing the rewritten parent rows. person_id is protected by
+        exclusion from the column allowlist, not by skipping the table."""
+        assert "person" not in constants.NATURAL_KEY_REWRITE_SKIP_TABLES
 
     def test_vocab_tables_skipped(self):
         """All vocabulary tables must be in the skip list (project rule)."""


### PR DESCRIPTION
- Remove `person` as a table to skip during natural key globalization; the FK columns `location_id`, `care_site_id`, and `provider_id` need to be rewritten to maintain referential integrity. The `person_id` column is not affected.