### PR TITLE
EHR merge functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The OMOP File Processor is a REST API service for processing healthcare data conforming to the OMOP Common Data Model (CDM). The service validates, normalizes, upgrades, and transforms OMOP data files, harmonizes vocabularies, filters Connect participants, generates derived tables and reporting artifacts, and loads processed data to BigQuery. The file processor is one of three components of the OMOP pipeline.
 
+The service also merges per-site deliveries into a single OMOP instance, combining each site's most recent `completed` delivery into one merged dataset under a separate merge DAG.
+
 The service is deployed as a Docker container on Google Cloud Run and integrates with Airflow DAGs for orchestration. The repository also includes Cloud Run job entry points for long-running processing stages that the orchestrator runs directly. Additional pipeline documentation is available in the [`ehr-pipeline-documentation`](https://github.com/Analyticsphere/ehr-pipeline-documentation) repository, including the [OMOP pipeline user guide](https://github.com/Analyticsphere/ehr-pipeline-documentation/wiki/OMOP-Pipeline-User-Guide).
 
 ### Current Support
@@ -55,6 +57,7 @@ Artifacts are created under `{bucket}/{delivery_date}/artifacts/`.
 | `artifacts/invalid_rows/` | Invalid rows removed during normalization |
 | `artifacts/connect_data/` | Exported Connect participant status Parquet file |
 | `artifacts/post_processing/` | Temporary per-task snapshots used by post-processing diff reporting |
+| `artifacts/merge_chunks/` | Provenance-named per-table chunks staged during a merge run (`<table>__<site>__<delivery_date>.parquet`, grouped by table) |
 | `artifacts/dqd/` | Reserved artifact directory |
 | `artifacts/achilles/` | Reserved artifact directory |
 | `artifacts/pass/` | Reserved artifact directory |
@@ -168,6 +171,7 @@ docker build -t omop-processor:local .
 - Service concurrency: `1`
 - Service timeout: `3600s`
 - Harmonization job timeout: `7200s`
+- Merge job timeouts: `3600s`
 - Other job timeouts: `3600s`
 - DuckDB temp volume mounted at `/mnt/data`
 
@@ -627,9 +631,9 @@ The endpoint details below are listed in the order each endpoint first appears i
 
 **Notes:**
 
-- If `cdm_source.parquet` exists with exactly one row, the endpoint keeps every site-delivered column **except** `source_release_date` and `cdm_release_date`, which are always rewritten:
-    - `source_release_date` keeps the site's value if it parses as a valid date; otherwise it falls back to `delivery_date`.
-    - `cdm_release_date` is unconditionally set to `delivery_date`.
+- If `cdm_source.parquet` exists with exactly one row, the endpoint keeps every site-delivered descriptive column but overwrites the pipeline-controlled fields:
+    - `source_release_date` and `cdm_release_date` keep the site's value if it parses as a valid date; otherwise they fall back to `delivery_date`.
+    - `cdm_version`, `cdm_version_concept_id`, and `vocabulary_version` are overwritten with the target values the pipeline standardized to (`target_cdm_version` / `target_vocab_version`); the site's self-reported values are discarded.
 - If the file does not exist, exists with zero rows, or exists with more than one row, it is populated from the request payload (all rows overwritten).
 - On the populate path: `source_release_date` is wrapped in a date-cast fallback chain (falls back to `delivery_date` if unparseable). `cdm_release_date` is unconditionally set to `delivery_date`. Although the request's `cdm_release_date` field is still required, its value is ignored.
 - The "Source system extraction date" report artifact is always written; if the cdm_source `source_release_date` value cannot be parsed, the artifact falls back to `delivery_date`.
@@ -1289,6 +1293,220 @@ Successfully loaded 2 derived table(s): drug_era, condition_era
 }
 ```
 
+## Merge Pipeline Endpoints
+
+The endpoints below implement the EHR PR2 merge pipeline, which combines each site's most recent `completed` delivery into a single merged OMOP instance. They are driven by a separate merge DAG, not the single-site `ehr_pipeline.py` DAG documented above. A merge run discovers each site's latest completed delivery, extracts every source table into provenance-named chunks under `artifacts/merge_chunks/`, reconciles those chunks into merged `converted_files/` tables, builds the merged instance's `care_site` and `cdm_source`, and records merge provenance.
+
+---
+
+### Get Latest Completed Delivery
+
+**Endpoint:** `POST /get_latest_completed_delivery`
+
+**Description:** Returns the `delivery_date` of a site's most recent `completed` delivery via a server-side `MAX(delivery_date)` query against the BigQuery logging table, or `null` if the site has no completed delivery (or the logging table does not exist yet).
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `site` | string | Yes | Site identifier (`site_name` in the logging table) |
+
+**Response:**
+
+```json
+{
+  "status": "healthy",
+  "delivery_date": "2024-01-15",
+  "service": "omop-file-processor"
+}
+```
+
+---
+
+### Get Delivery CDM Version
+
+**Endpoint:** `POST /get_delivery_cdm_version`
+
+**Description:** Reads the CDM and vocabulary versions a processed delivery was standardized to from its `artifacts/converted_files/cdm_source.parquet`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `bucket` | string | Yes | Bucket or root directory of the source delivery |
+| `delivery_date` | string | Yes | Delivery date in `YYYY-MM-DD` format |
+
+**Notes:**
+
+- This is the standardized version for a processed delivery; the delivered version recorded in site config and the BigQuery log is not the same thing.
+- Both fields are `null` if the `cdm_source` file has no rows.
+
+**Response:**
+
+```json
+{
+  "status": "healthy",
+  "cdm_version": "5.4",
+  "vocabulary_version": "v5.0 29-FEB-24",
+  "service": "omop-file-processor"
+}
+```
+
+---
+
+### Extract Participant Chunk
+
+**Endpoint:** `POST /extract_participant_chunk`
+
+**DAG usage:** Implemented in the merge DAG through `core.jobs.extract_participant_chunk_job`.
+
+**Description:** Copies one source-delivery table into a provenance-named chunk file (`<table>__<site>__<delivery_date>.parquet`) under `artifacts/merge_chunks/<table>/`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `source_uri` | string | Yes | Path to the source delivery's table Parquet |
+| `chunk_uri` | string | Yes | Destination chunk Parquet path in the staging area |
+| `site_display_name` | string | No | Source site name. When set (`person` only), stamps `care_site_id` with a deterministic hash of the name so each merged patient records its origin site |
+
+**Example:**
+
+```json
+{
+  "source_uri": "site-a/2024-01-15/artifacts/converted_files/person.parquet",
+  "chunk_uri": "merged/2024-08-03/artifacts/merge_chunks/person/person__site-a__2024-01-15.parquet",
+  "site_display_name": "Hospital A"
+}
+```
+
+---
+
+### Reconcile Chunks
+
+**Endpoint:** `POST /reconcile_chunks`
+
+**DAG usage:** Implemented in the merge DAG through `core.jobs.reconcile_chunks_job`.
+
+**Description:** Unions a table's chunk files into a single merged `converted_files/<table>.parquet`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `chunk_glob` | string | Yes | Glob over the per-table staging folder, e.g. `.../merge_chunks/<table>/*.parquet` |
+| `output_uri` | string | Yes | Destination for the reconciled table |
+
+**Notes:**
+
+- `output_uri` must live outside the chunk folder (in `converted_files/`) so the read glob never re-reads its own output.
+- Chunks are unioned with `union_by_name=true`.
+
+**Example:**
+
+```json
+{
+  "chunk_glob": "merged/2024-08-03/artifacts/merge_chunks/person/*.parquet",
+  "output_uri": "merged/2024-08-03/artifacts/converted_files/person.parquet"
+}
+```
+
+---
+
+### Build Care Site
+
+**Endpoint:** `POST /build_care_site`
+
+**Description:** Writes the merged instance's `care_site` table: one row per merged site mapping its hashed `care_site_id` to `care_site_name`, all other columns `NULL`. `care_site` rows are not carried over from the individual deliveries.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `output_uri` | string | Yes | Destination for the `care_site` Parquet |
+| `site_display_names` | list | Yes | Display names of the merged sites (de-duplicated, first-seen order preserved) |
+| `cdm_version` | string | Yes | OMOP CDM version used to resolve the `care_site` schema |
+
+**Example:**
+
+```json
+{
+  "output_uri": "merged/2024-08-03/artifacts/converted_files/care_site.parquet",
+  "site_display_names": ["Hospital A", "Hospital B"],
+  "cdm_version": "5.4"
+}
+```
+
+---
+
+### Build Merge CDM Source
+
+**Endpoint:** `POST /build_merge_cdm_source`
+
+**Description:** Writes a de novo one-row `cdm_source` for the merged instance using fixed Connect metadata plus the merged site count.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `output_uri` | string | Yes | Destination for the `cdm_source` Parquet |
+| `source_cdm_source_uris` | list | Yes | Source deliveries' `cdm_source` Parquet paths, used to derive `source_release_date` |
+| `site_count` | integer | Yes | Number of merged sites (written into the source description) |
+| `cdm_version` | string | Yes | Target OMOP CDM version (drives `cdm_version_concept_id`) |
+| `vocabulary_version` | string | Yes | Target vocabulary version |
+| `cdm_release_date` | string | Yes | Merge run date, written to `cdm_release_date` |
+
+**Notes:**
+
+- `source_release_date` is the latest across the source deliveries' `cdm_source` files, falling back to `cdm_release_date` if none is present.
+
+**Example:**
+
+```json
+{
+  "output_uri": "merged/2024-08-03/artifacts/converted_files/cdm_source.parquet",
+  "source_cdm_source_uris": [
+    "site-a/2024-01-15/artifacts/converted_files/cdm_source.parquet",
+    "site-b/2024-02-01/artifacts/converted_files/cdm_source.parquet"
+  ],
+  "site_count": 2,
+  "cdm_version": "5.4",
+  "vocabulary_version": "v5.0 29-FEB-24",
+  "cdm_release_date": "2024-08-03"
+}
+```
+
+---
+
+### Generate Merge Report
+
+**Endpoint:** `POST /generate_merge_report`
+
+**Description:** Records merge provenance — the distinct sites merged, each `(site, delivery_date)` delivery and the row count it contributed, and the merge-wide total — as report artifacts consolidated into a delivery report CSV.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `merge_bucket` | string | Yes | The merged instance's bucket |
+| `run_date` | string | Yes | The merged instance's delivery-date slot in `YYYY-MM-DD` format |
+| `site` | string | Yes | Synthetic merge `site_name` used for the report CSV file name |
+| `deliveries` | list | Yes | Source deliveries in the run, each `{"site", "delivery_date"}` |
+
+**Example:**
+
+```json
+{
+  "merge_bucket": "merged",
+  "run_date": "2024-08-03",
+  "site": "connect_ehr",
+  "deliveries": [
+    {"site": "site-a", "delivery_date": "2024-01-15"},
+    {"site": "site-b", "delivery_date": "2024-02-01"}
+  ]
+}
+```
+
 ## Cloud Run Jobs
 
 The repository also exposes direct job entry points under `core/jobs/`.
@@ -1303,6 +1521,8 @@ The repository also exposes direct job entry points under `core/jobs/`.
 | `core.jobs.post_processing_job` | `SITE`, `GCS_BUCKET`, `DELIVERY_DATE`, `CDM_VERSION`, `VOCAB_VERSION`, `TASK_NAME` | `POST /post_processing` |
 | `core.jobs.generate_derived_tables_job` | `SITE`, `GCS_BUCKET`, `DELIVERY_DATE`, `TABLE_NAME`, `VOCAB_VERSION` | `POST /generate_derived_tables_from_harmonized` |
 | `core.jobs.generate_report_csv_job` | `SITE`, `GCS_BUCKET`, `DELIVERY_DATE`, `SITE_DISPLAY_NAME`, `FILE_DELIVERY_FORMAT`, `DELIVERED_CDM_VERSION`, `TARGET_VOCABULARY_VERSION`, `TARGET_CDM_VERSION`; optional `ARTIFACT_TYPE` to generate one artifact type or run the final consolidation | `POST /generate_delivery_report_csv` |
+| `core.jobs.extract_participant_chunk_job` | `SOURCE_URI`, `CHUNK_URI`; optional `SITE_DISPLAY_NAME` | `POST /extract_participant_chunk` |
+| `core.jobs.reconcile_chunks_job` | `CHUNK_GLOB`, `OUTPUT_URI` | `POST /reconcile_chunks` |
 
 ## Running Tests
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -234,9 +234,7 @@ substitutions:
   _DEFAULT_TASK_TIMEOUT: '3600s'
   _SERVICE_TIMEOUT: '3600s'
   _HARMONIZE_VOCAB_TIMEOUT: '7200s'
-  # Merge jobs (extract/reconcile) operate on multi-site data and can run long;
-  # give them more headroom than the default task timeout.
-  _MERGE_TASK_TIMEOUT: '7200s'
+  _MERGE_TASK_TIMEOUT: '3600s'
 
 images:
   - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:$COMMIT_SHA'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -183,6 +183,44 @@ steps:
     '--args=python,-m,core.jobs.generate_report_csv_job'
   ]
 
+# Deploy Cloud Run Job: Extract Participant Chunk (EHR PR2 merge pipeline)
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args: [
+    'run', 'jobs', 'deploy', 'ccc-omop-file-processor-extract-participant-chunk-job',
+    '--image=gcr.io/$PROJECT_ID/$_IMAGE_NAME:$COMMIT_SHA',
+    '--region=us-central1',
+    '--service-account=$SERVICE_ACCOUNT_EMAIL',
+    '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_MERGE_TASK_TIMEOUT',
+    '--max-retries=0',
+    '--parallelism=1',
+    '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
+    '--add-volume-mount=volume=duckdb_files,mount-path=/mnt/data',
+    '--args=python,-m,core.jobs.extract_participant_chunk_job'
+  ]
+
+# Deploy Cloud Run Job: Reconcile Chunks (EHR PR2 merge pipeline)
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args: [
+    'run', 'jobs', 'deploy', 'ccc-omop-file-processor-reconcile-chunks-job',
+    '--image=gcr.io/$PROJECT_ID/$_IMAGE_NAME:$COMMIT_SHA',
+    '--region=us-central1',
+    '--service-account=$SERVICE_ACCOUNT_EMAIL',
+    '--set-env-vars=PROJECT_ID=$PROJECT_ID,COMMIT_SHA=$COMMIT_SHA,BQ_LOGGING_TABLE=$_BQ_LOGGING_TABLE,OMOP_VOCAB_PATH=$_OMOP_VOCAB_PATH',
+    '--cpu=$_DEFAULT_CPU',
+    '--memory=$_DEFAULT_MEMORY',
+    '--task-timeout=$_MERGE_TASK_TIMEOUT',
+    '--max-retries=0',
+    '--parallelism=1',
+    '--add-volume=name=duckdb_files,type=cloud-storage,bucket=$_TMP_DIRECTORY',
+    '--add-volume-mount=volume=duckdb_files,mount-path=/mnt/data',
+    '--args=python,-m,core.jobs.reconcile_chunks_job'
+  ]
+
 options:
   logging: CLOUD_LOGGING_ONLY
 
@@ -196,6 +234,9 @@ substitutions:
   _DEFAULT_TASK_TIMEOUT: '3600s'
   _SERVICE_TIMEOUT: '3600s'
   _HARMONIZE_VOCAB_TIMEOUT: '7200s'
+  # Merge jobs (extract/reconcile) operate on multi-site data and can run long;
+  # give them more headroom than the default task timeout.
+  _MERGE_TASK_TIMEOUT: '7200s'
 
 images:
   - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:$COMMIT_SHA'

--- a/core/constants.py
+++ b/core/constants.py
@@ -165,6 +165,9 @@ class ArtifactPaths(str, Enum):
     INVALID_ROWS = f"{ARTIFACTS}invalid_rows/"
     CONNECT_DATA = f"{ARTIFACTS}connect_data/"
     POST_PROCESSING_TMP = f"{ARTIFACTS}post_processing/"
+    # EHR PR2 merge pipeline: shared per-table staging area for provenance-named
+    # chunk files extracted from each source delivery before reconciliation.
+    MERGE_CHUNKS = f"{ARTIFACTS}merge_chunks/"
 
 # Using -1 as place/holder default value for numeric columns 
 #   as these are uncommon values in real data
@@ -608,3 +611,14 @@ GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS = [
 # person_id is protected by exclusion from GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS,
 # not by skipping the table.
 NATURAL_KEY_REWRITE_SKIP_TABLES = VOCABULARY_TABLES
+
+# ---------------------------------------------------------------------------
+# EHR PR2 merge pipeline
+# ---------------------------------------------------------------------------
+# Sentinel PARTICIPANT_SCOPE value meaning "extract the whole source table" (no
+# participant WHERE clause). Any other value is treated as a GCS/URI reference to
+# a parquet file of participant ids to subset by (v2 path; designed-for now).
+PARTICIPANT_SCOPE_ALL = "ALL"
+
+# Default person_id column used when subsetting a chunk by participant scope.
+DEFAULT_PERSON_ID_COLUMN = "person_id"

--- a/core/constants.py
+++ b/core/constants.py
@@ -165,14 +165,10 @@ class ArtifactPaths(str, Enum):
     INVALID_ROWS = f"{ARTIFACTS}invalid_rows/"
     CONNECT_DATA = f"{ARTIFACTS}connect_data/"
     POST_PROCESSING_TMP = f"{ARTIFACTS}post_processing/"
-    # EHR PR2 merge pipeline: shared per-table staging area for provenance-named
-    # chunk files extracted from each source delivery before reconciliation.
     MERGE_CHUNKS = f"{ARTIFACTS}merge_chunks/"
 
-# Using -1 as place/holder default value for numeric columns 
-#   as these are uncommon values in real data
-# Using date 1970-01-01 because it's the Unix epoch, and it's
-#   unlikely that this date will appear in real data
+# Using -1 as place/holder default value for numeric columns  as these are uncommon values in real data
+# Using date 1970-01-01 because it's the Unix epoch, and it's unlikely this date will appear in real data
 DEFAULT_DATE = "1970-01-01"
 DEFAULT_COLUMN_VALUES = {
         "VARCHAR": "''",
@@ -606,10 +602,8 @@ GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS = [
 ]
 
 # Tables that are not rewritten by the natural-key globalization step.
-# person is NOT skipped: it has location_id/provider_id/care_site_id FK columns
-# that must be globalized so they continue to reference rewritten parent rows.
-# person_id is protected by exclusion from GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS,
-# not by skipping the table.
+# person is NOT skipped: it has location_id/provider_id/care_site_id FK columns that must be globalized so they continue to reference rewritten parent rows.
+# person_id is protected by exclusion from GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS, not by skipping the table.
 NATURAL_KEY_REWRITE_SKIP_TABLES = VOCABULARY_TABLES
 
 # ---------------------------------------------------------------------------

--- a/core/constants.py
+++ b/core/constants.py
@@ -606,21 +606,13 @@ GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS = [
 # person_id is protected by exclusion from GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS, not by skipping the table.
 NATURAL_KEY_REWRITE_SKIP_TABLES = VOCABULARY_TABLES
 
-# ---------------------------------------------------------------------------
-# EHR PR2 merge pipeline
-# ---------------------------------------------------------------------------
+
 # Sentinel PARTICIPANT_SCOPE value meaning "extract the whole source table" (no
 # participant WHERE clause). Any other value is treated as a GCS/URI reference to
 # a parquet file of participant ids to subset by (v2 path; designed-for now).
 PARTICIPANT_SCOPE_ALL = "ALL"
 
-# Default person_id column used when subsetting a chunk by participant scope.
-DEFAULT_PERSON_ID_COLUMN = "person_id"
-
-# Fixed cdm_source metadata for the merged (de novo) instance. The merge writes ONE
-# row describing the combined product; it does NOT union the sites' cdm_source rows.
-# {site_count} is filled with the number of merged sites; source/cdm release dates
-# and CDM/vocab versions are supplied at build time.
+# Fixed cdm_source metadata for the merged instance.
 MERGE_CDM_SOURCE_NAME = "Connect for Cancer Prevention Study - EHR Data"
 MERGE_CDM_SOURCE_ABBREVIATION = "Connect EHR Data"
 MERGE_CDM_HOLDER = "NIH/NCI - Connect for Cancer Prevention Study"

--- a/core/constants.py
+++ b/core/constants.py
@@ -607,11 +607,6 @@ GLOBALLY_UNIQUE_NATURAL_KEY_COLUMNS = [
 NATURAL_KEY_REWRITE_SKIP_TABLES = VOCABULARY_TABLES
 
 
-# Sentinel PARTICIPANT_SCOPE value meaning "extract the whole source table" (no
-# participant WHERE clause). Any other value is treated as a GCS/URI reference to
-# a parquet file of participant ids to subset by (v2 path; designed-for now).
-PARTICIPANT_SCOPE_ALL = "ALL"
-
 # Fixed cdm_source metadata for the merged instance.
 MERGE_CDM_SOURCE_NAME = "Connect for Cancer Prevention Study - EHR Data"
 MERGE_CDM_SOURCE_ABBREVIATION = "Connect EHR Data"

--- a/core/constants.py
+++ b/core/constants.py
@@ -627,7 +627,7 @@ DEFAULT_PERSON_ID_COLUMN = "person_id"
 # row describing the combined product; it does NOT union the sites' cdm_source rows.
 # {site_count} is filled with the number of merged sites; source/cdm release dates
 # and CDM/vocab versions are supplied at build time.
-MERGE_CDM_SOURCE_NAME = "Connect for Cancer Prevention EHR Data"
+MERGE_CDM_SOURCE_NAME = "Connect for Cancer Prevention Study - EHR Data"
 MERGE_CDM_SOURCE_ABBREVIATION = "Connect EHR Data"
 MERGE_CDM_HOLDER = "NIH/NCI - Connect for Cancer Prevention Study"
 MERGE_CDM_SOURCE_DESCRIPTION = "Combined EHR data from {site_count} sites participating in the Connect for Cancer Prevention Study"

--- a/core/constants.py
+++ b/core/constants.py
@@ -622,3 +622,14 @@ PARTICIPANT_SCOPE_ALL = "ALL"
 
 # Default person_id column used when subsetting a chunk by participant scope.
 DEFAULT_PERSON_ID_COLUMN = "person_id"
+
+# Fixed cdm_source metadata for the merged (de novo) instance. The merge writes ONE
+# row describing the combined product; it does NOT union the sites' cdm_source rows.
+# {site_count} is filled with the number of merged sites; source/cdm release dates
+# and CDM/vocab versions are supplied at build time.
+MERGE_CDM_SOURCE_NAME = "Connect for Cancer Prevention EHR Data"
+MERGE_CDM_SOURCE_ABBREVIATION = "Connect EHR"
+MERGE_CDM_HOLDER = "NIH/NCI - Connect for Cancer Prevention Study"
+MERGE_CDM_SOURCE_DESCRIPTION = "Combined EHR data from {site_count} sites participating in the Connect for Cancer Prevention Study"
+MERGE_SOURCE_DOCUMENTATION_REFERENCE = "https://www.cancer.gov/connect-prevention-study/"
+MERGE_CDM_ETL_REFERENCE = "https://github.com/Analyticsphere/ccc-omop-file-processor"

--- a/core/constants.py
+++ b/core/constants.py
@@ -628,7 +628,7 @@ DEFAULT_PERSON_ID_COLUMN = "person_id"
 # {site_count} is filled with the number of merged sites; source/cdm release dates
 # and CDM/vocab versions are supplied at build time.
 MERGE_CDM_SOURCE_NAME = "Connect for Cancer Prevention EHR Data"
-MERGE_CDM_SOURCE_ABBREVIATION = "Connect EHR"
+MERGE_CDM_SOURCE_ABBREVIATION = "Connect EHR Data"
 MERGE_CDM_HOLDER = "NIH/NCI - Connect for Cancer Prevention Study"
 MERGE_CDM_SOURCE_DESCRIPTION = "Combined EHR data from {site_count} sites participating in the Connect for Cancer Prevention Study"
 MERGE_SOURCE_DOCUMENTATION_REFERENCE = "https://www.cancer.gov/connect-prevention-study/"

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -9,6 +9,7 @@ import core.file_processor as file_processor
 import core.file_validation as file_validation
 import core.gcp_services as gcp_services
 import core.helpers.pipeline_log as pipeline_log
+import core.merge as merge
 import core.natural_keys as natural_keys
 import core.normalization as normalization
 import core.omop_client as omop_client
@@ -836,6 +837,117 @@ def load_derived_tables_to_bq() -> tuple[str, int]:
     except Exception as e:
         utils.logger.error(f"Error loading derived tables to BigQuery: {str(e)}")
         return f"Error loading derived tables to BigQuery: {str(e)}", 500
+
+
+# ---------------------------------------------------------------------------
+# EHR PR2 merge pipeline
+# ---------------------------------------------------------------------------
+
+@app.route('/get_latest_completed_delivery', methods=['POST'])
+def get_latest_completed_delivery() -> tuple[Any, int]:
+    """Return the delivery_date of a site's most recent 'completed' delivery, or null."""
+    data: dict[str, Any] = request.get_json() or {}
+    site: Optional[str] = data.get('site')
+    missing_fields = _get_missing_fields(data, ['site'])
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert site is not None
+
+        delivery_date: Optional[str] = pipeline_log.get_latest_completed_delivery(site)
+        return jsonify({
+            'status': 'healthy',
+            'delivery_date': delivery_date,
+            'service': constants.SERVICE_NAME
+        }), 200
+    except Exception as e:
+        utils.logger.error(f"Unable to get latest completed delivery for {site}: {str(e)}")
+        return f"Unable to get latest completed delivery for {site}: {str(e)}", 500
+
+
+@app.route('/get_delivery_cdm_version', methods=['POST'])
+def get_delivery_cdm_version() -> tuple[Any, int]:
+    """Return the CDM and vocabulary versions a processed delivery was standardized to."""
+    data: dict[str, Any] = request.get_json() or {}
+    bucket: Optional[str] = data.get('bucket')
+    delivery_date: Optional[str] = data.get('delivery_date')
+    missing_fields = _get_missing_fields(data, ['bucket', 'delivery_date'])
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert bucket is not None
+        assert delivery_date is not None
+
+        versions = omop_client.OMOPClient.get_delivery_cdm_version(bucket, delivery_date)
+        return jsonify({
+            'status': 'healthy',
+            'cdm_version': versions['cdm_version'],
+            'vocabulary_version': versions['vocabulary_version'],
+            'service': constants.SERVICE_NAME
+        }), 200
+    except Exception as e:
+        utils.logger.error(f"Unable to read cdm_version for {bucket}/{delivery_date}: {str(e)}")
+        return f"Unable to read cdm_version for {bucket}/{delivery_date}: {str(e)}", 500
+
+
+@app.route('/extract_participant_chunk', methods=['POST'])
+def extract_participant_chunk() -> tuple[str, int]:
+    """
+    Copy one source-delivery table into a provenance-named merge chunk file.
+
+    For v1, participant_scope is always "ALL" (whole table). A participant-id subset
+    (v2) is supported by pointing participant_scope at a parquet of ids.
+    """
+    data: dict[str, Any] = request.get_json() or {}
+    source_uri: Optional[str] = data.get('source_uri')
+    chunk_uri: Optional[str] = data.get('chunk_uri')
+    participant_scope: Optional[str] = data.get('participant_scope')
+    person_id_column: str = data.get('person_id_column') or constants.DEFAULT_PERSON_ID_COLUMN
+    missing_fields = _get_missing_fields(data, ['source_uri', 'chunk_uri', 'participant_scope'])
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert source_uri is not None
+        assert chunk_uri is not None
+        assert participant_scope is not None
+
+        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, participant_scope, person_id_column)
+        return "Extracted participant chunk", 200
+    except Exception as e:
+        utils.logger.error(f"Unable to extract participant chunk: {str(e)}")
+        return f"Unable to extract participant chunk: {str(e)}", 500
+
+
+@app.route('/reconcile_chunks', methods=['POST'])
+def reconcile_chunks() -> tuple[str, int]:
+    """Union all chunk files for a table into a single merged parquet in converted_files/."""
+    data: dict[str, Any] = request.get_json() or {}
+    chunk_glob: Optional[str] = data.get('chunk_glob')
+    output_uri: Optional[str] = data.get('output_uri')
+    missing_fields = _get_missing_fields(data, ['chunk_glob', 'output_uri'])
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert chunk_glob is not None
+        assert output_uri is not None
+
+        merge.MergeProcessor.reconcile_chunks(chunk_glob, output_uri)
+        return "Reconciled merge chunks", 200
+    except Exception as e:
+        utils.logger.error(f"Unable to reconcile merge chunks: {str(e)}")
+        return f"Unable to reconcile merge chunks: {str(e)}", 500
 
 
 @app.route('/pipeline_log', methods=['POST'])

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -910,6 +910,8 @@ def extract_participant_chunk() -> tuple[str, int]:
     chunk_uri: Optional[str] = data.get('chunk_uri')
     participant_scope: Optional[str] = data.get('participant_scope')
     person_id_column: str = data.get('person_id_column') or constants.DEFAULT_PERSON_ID_COLUMN
+    # Optional: only the person table passes this, to stamp care_site_id with the origin site's hash.
+    site_display_name: Optional[str] = data.get('site_display_name')
     missing_fields = _get_missing_fields(data, ['source_uri', 'chunk_uri', 'participant_scope'])
 
     # Validate required parameters
@@ -921,7 +923,7 @@ def extract_participant_chunk() -> tuple[str, int]:
         assert chunk_uri is not None
         assert participant_scope is not None
 
-        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, participant_scope, person_id_column)
+        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, participant_scope, person_id_column, site_display_name)
         return "Extracted participant chunk", 200
     except Exception as e:
         utils.logger.error(f"Unable to extract participant chunk: {str(e)}")
@@ -949,6 +951,31 @@ def reconcile_chunks() -> tuple[str, int]:
     except Exception as e:
         utils.logger.error(f"Unable to reconcile merge chunks: {str(e)}")
         return f"Unable to reconcile merge chunks: {str(e)}", 500
+
+
+@app.route('/build_care_site', methods=['POST'])
+def build_care_site() -> tuple[str, int]:
+    """Build the merged instance's care_site table (one hashed-id row per merged site)."""
+    data: dict[str, Any] = request.get_json() or {}
+    output_uri: Optional[str] = data.get('output_uri')
+    site_display_names: Optional[list] = data.get('site_display_names')
+    cdm_version: Optional[str] = data.get('cdm_version')
+    missing_fields = _get_missing_fields(data, ['output_uri', 'site_display_names', 'cdm_version'])
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert output_uri is not None
+        assert site_display_names is not None
+        assert cdm_version is not None
+
+        merge.MergeProcessor.build_care_site(output_uri, site_display_names, cdm_version)
+        return "Built care_site table", 200
+    except Exception as e:
+        utils.logger.error(f"Unable to build care_site table: {str(e)}")
+        return f"Unable to build care_site table: {str(e)}", 500
 
 
 @app.route('/generate_merge_report', methods=['POST'])

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -840,10 +840,6 @@ def load_derived_tables_to_bq() -> tuple[str, int]:
         return f"Error loading derived tables to BigQuery: {str(e)}", 500
 
 
-# ---------------------------------------------------------------------------
-# EHR PR2 merge pipeline
-# ---------------------------------------------------------------------------
-
 @app.route('/get_latest_completed_delivery', methods=['POST'])
 def get_latest_completed_delivery() -> tuple[Any, int]:
     """Return the delivery_date of a site's most recent 'completed' delivery, or null."""

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -899,19 +899,13 @@ def get_delivery_cdm_version() -> tuple[Any, int]:
 
 @app.route('/extract_participant_chunk', methods=['POST'])
 def extract_participant_chunk() -> tuple[str, int]:
-    """
-    Copy one source-delivery table into a provenance-named merge chunk file.
-
-    For v1, participant_scope is always "ALL" (whole table). A participant-id subset
-    (v2) is supported by pointing participant_scope at a parquet of ids.
-    """
+    """Copy one source-delivery table into a provenance-named merge chunk file."""
     data: dict[str, Any] = request.get_json() or {}
     source_uri: Optional[str] = data.get('source_uri')
     chunk_uri: Optional[str] = data.get('chunk_uri')
-    participant_scope: Optional[str] = data.get('participant_scope')
     # Optional: only the person table passes this, to stamp care_site_id with the origin site's hash.
     site_display_name: Optional[str] = data.get('site_display_name')
-    missing_fields = _get_missing_fields(data, ['source_uri', 'chunk_uri', 'participant_scope'])
+    missing_fields = _get_missing_fields(data, ['source_uri', 'chunk_uri'])
 
     # Validate required parameters
     if missing_fields:
@@ -920,9 +914,8 @@ def extract_participant_chunk() -> tuple[str, int]:
     try:
         assert source_uri is not None
         assert chunk_uri is not None
-        assert participant_scope is not None
 
-        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, participant_scope, site_display_name)
+        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, site_display_name)
         return "Extracted participant chunk", 200
     except Exception as e:
         utils.logger.error(f"Unable to extract participant chunk: {str(e)}")

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -978,6 +978,42 @@ def build_care_site() -> tuple[str, int]:
         return f"Unable to build care_site table: {str(e)}", 500
 
 
+@app.route('/build_merge_cdm_source', methods=['POST'])
+def build_merge_cdm_source() -> tuple[str, int]:
+    """Build the merged instance's de novo one-row cdm_source parquet."""
+    data: dict[str, Any] = request.get_json() or {}
+    output_uri: Optional[str] = data.get('output_uri')
+    source_cdm_source_uris: Optional[list] = data.get('source_cdm_source_uris')
+    site_count: Optional[int] = data.get('site_count')
+    cdm_version: Optional[str] = data.get('cdm_version')
+    vocabulary_version: Optional[str] = data.get('vocabulary_version')
+    cdm_release_date: Optional[str] = data.get('cdm_release_date')
+    missing_fields = _get_missing_fields(
+        data,
+        ['output_uri', 'source_cdm_source_uris', 'site_count', 'cdm_version', 'vocabulary_version', 'cdm_release_date']
+    )
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert output_uri is not None
+        assert source_cdm_source_uris is not None
+        assert site_count is not None
+        assert cdm_version is not None
+        assert vocabulary_version is not None
+        assert cdm_release_date is not None
+
+        merge.MergeProcessor.build_cdm_source(
+            output_uri, source_cdm_source_uris, site_count, cdm_version, vocabulary_version, cdm_release_date
+        )
+        return "Built cdm_source", 200
+    except Exception as e:
+        utils.logger.error(f"Unable to build cdm_source: {str(e)}")
+        return f"Unable to build cdm_source: {str(e)}", 500
+
+
 @app.route('/generate_merge_report', methods=['POST'])
 def generate_merge_report() -> tuple[str, int]:
     """Generate merge provenance report artifacts + consolidated CSV."""

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -909,7 +909,6 @@ def extract_participant_chunk() -> tuple[str, int]:
     source_uri: Optional[str] = data.get('source_uri')
     chunk_uri: Optional[str] = data.get('chunk_uri')
     participant_scope: Optional[str] = data.get('participant_scope')
-    person_id_column: str = data.get('person_id_column') or constants.DEFAULT_PERSON_ID_COLUMN
     # Optional: only the person table passes this, to stamp care_site_id with the origin site's hash.
     site_display_name: Optional[str] = data.get('site_display_name')
     missing_fields = _get_missing_fields(data, ['source_uri', 'chunk_uri', 'participant_scope'])
@@ -923,7 +922,7 @@ def extract_participant_chunk() -> tuple[str, int]:
         assert chunk_uri is not None
         assert participant_scope is not None
 
-        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, participant_scope, person_id_column, site_display_name)
+        merge.MergeProcessor.extract_chunk(source_uri, chunk_uri, participant_scope, site_display_name)
         return "Extracted participant chunk", 200
     except Exception as e:
         utils.logger.error(f"Unable to extract participant chunk: {str(e)}")

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -10,6 +10,7 @@ import core.file_validation as file_validation
 import core.gcp_services as gcp_services
 import core.helpers.pipeline_log as pipeline_log
 import core.merge as merge
+import core.merge_reporting as merge_reporting
 import core.natural_keys as natural_keys
 import core.normalization as normalization
 import core.omop_client as omop_client
@@ -948,6 +949,33 @@ def reconcile_chunks() -> tuple[str, int]:
     except Exception as e:
         utils.logger.error(f"Unable to reconcile merge chunks: {str(e)}")
         return f"Unable to reconcile merge chunks: {str(e)}", 500
+
+
+@app.route('/generate_merge_report', methods=['POST'])
+def generate_merge_report() -> tuple[str, int]:
+    """Generate merge provenance report artifacts + consolidated CSV."""
+    data: dict[str, Any] = request.get_json() or {}
+    merge_bucket: Optional[str] = data.get('merge_bucket')
+    run_date: Optional[str] = data.get('run_date')
+    site: Optional[str] = data.get('site')
+    deliveries: Optional[list] = data.get('deliveries')
+    missing_fields = _get_missing_fields(data, ['merge_bucket', 'run_date', 'site', 'deliveries'])
+
+    # Validate required parameters
+    if missing_fields:
+        return _missing_fields_response(missing_fields)
+
+    try:
+        assert merge_bucket is not None
+        assert run_date is not None
+        assert site is not None
+        assert deliveries is not None
+
+        merge_reporting.MergeReporter.generate_merge_report(merge_bucket, run_date, site, deliveries)
+        return "Generated merge report", 200
+    except Exception as e:
+        utils.logger.error(f"Unable to generate merge report: {str(e)}")
+        return f"Unable to generate merge report: {str(e)}", 500
 
 
 @app.route('/pipeline_log', methods=['POST'])

--- a/core/helpers/pipeline_log.py
+++ b/core/helpers/pipeline_log.py
@@ -2,10 +2,65 @@ from datetime import datetime
 from typing import Optional
 
 from google.cloud import bigquery  # type: ignore
+from google.cloud.exceptions import NotFound  # type: ignore
 
 import core.constants as constants
 import core.gcp_services as gcp_services
 import core.utils as utils
+
+
+def get_latest_completed_delivery(site: str) -> Optional[str]:
+    """
+    Return the delivery_date of a site's most recent successfully-processed delivery.
+
+    "Latest" is MAX(delivery_date) among rows whose status is 'completed'. This is a
+    server-side query against the pipeline logging table.
+
+    Args:
+        site: The site_name to look up.
+
+    Returns:
+        The delivery_date as an ISO string (YYYY-MM-DD), or None if the site has no
+        completed delivery (or the logging table does not exist yet).
+    """
+    client = bigquery.Client()
+
+    # If the logging table doesn't exist yet (e.g. first run) there is nothing completed.
+    try:
+        client.get_table(constants.BQ_LOGGING_TABLE)
+    except NotFound:
+        return None
+
+    query = f"""
+        SELECT delivery_date
+        FROM `{constants.BQ_LOGGING_TABLE}`
+        WHERE site_name = @site
+          AND status = @status
+        ORDER BY delivery_date DESC
+        LIMIT 1
+    """
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("site", "STRING", site),
+            bigquery.ScalarQueryParameter("status", "STRING", constants.PIPELINE_COMPLETE_STRING),
+        ]
+    )
+
+    try:
+        query_job = client.query(query, job_config=job_config)
+        rows = list(query_job.result())
+
+        if not rows:
+            return None
+
+        delivery_date = rows[0]["delivery_date"]
+        # BigQuery DATE columns come back as datetime.date; normalize to YYYY-MM-DD.
+        if hasattr(delivery_date, "isoformat"):
+            return delivery_date.isoformat()
+        return str(delivery_date)
+    except Exception as e:
+        raise Exception(f"Failed to retrieve latest completed delivery for site '{site}': {e}") from e
 
 
 class PipelineLog:

--- a/core/jobs/extract_participant_chunk_job.py
+++ b/core/jobs/extract_participant_chunk_job.py
@@ -13,6 +13,7 @@ Required Environment Variables:
 
 Optional Environment Variables:
     PERSON_ID_COLUMN: Column matched against the id set when scope != "ALL" (default "person_id")
+    SITE_DISPLAY_NAME: Source site name; when set (person only), stamps care_site_id with its hash
 
 Exit Codes:
     0: Success
@@ -49,6 +50,9 @@ def validate_env_vars() -> dict[str, str]:
     # Optional: person_id column used only when subsetting by participant scope
     env_values['PERSON_ID_COLUMN'] = os.getenv('PERSON_ID_COLUMN', constants.DEFAULT_PERSON_ID_COLUMN)
 
+    # Optional: site name used to stamp care_site_id (person table only).
+    env_values['SITE_DISPLAY_NAME'] = os.getenv('SITE_DISPLAY_NAME', '')
+
     return env_values
 
 
@@ -66,6 +70,7 @@ def main():
     utils.logger.info(f"CHUNK_URI: {env_values['CHUNK_URI']}")
     utils.logger.info(f"PARTICIPANT_SCOPE: {env_values['PARTICIPANT_SCOPE']}")
     utils.logger.info(f"PERSON_ID_COLUMN: {env_values['PERSON_ID_COLUMN']}")
+    utils.logger.info(f"SITE_DISPLAY_NAME: {env_values['SITE_DISPLAY_NAME']}")
 
     try:
         merge.MergeProcessor.extract_chunk(
@@ -73,6 +78,8 @@ def main():
             chunk_uri=env_values['CHUNK_URI'],
             participant_scope=env_values['PARTICIPANT_SCOPE'],
             person_id_column=env_values['PERSON_ID_COLUMN'],
+            # Empty env var -> None (no stamping); set only for person.
+            site_display_name=env_values['SITE_DISPLAY_NAME'] or None,
         )
 
         utils.logger.info("=" * 80)

--- a/core/jobs/extract_participant_chunk_job.py
+++ b/core/jobs/extract_participant_chunk_job.py
@@ -3,13 +3,11 @@
 Cloud Run Job entry point for extracting a (group x table) chunk from a source delivery.
 
 Copies one source table into a provenance-named chunk file in the shared per-table
-merge staging area. For v1 the participant scope is always "ALL" (whole table); a
-participant-id subset (v2) is supported by pointing PARTICIPANT_SCOPE at a parquet of Connect IDs.
+merge staging area.
 
 Required Environment Variables:
     SOURCE_URI: Path to the source delivery's table parquet (e.g. .../converted_files/<table>.parquet)
     CHUNK_URI: Destination chunk parquet path in the staging area
-    PARTICIPANT_SCOPE: "ALL" for the whole table, otherwise a path to a parquet of participant ids
 
 Optional Environment Variables:
     SITE_DISPLAY_NAME: Source site name; when set (person only), stamps care_site_id with its hash
@@ -29,7 +27,7 @@ import core.utils as utils
 
 def validate_env_vars() -> dict[str, str]:
     """Validate and return required environment variables."""
-    required_vars = ['SOURCE_URI', 'CHUNK_URI', 'PARTICIPANT_SCOPE']
+    required_vars = ['SOURCE_URI', 'CHUNK_URI']
 
     env_values = {}
     missing_vars = []
@@ -63,14 +61,12 @@ def main():
 
     utils.logger.info(f"SOURCE_URI: {env_values['SOURCE_URI']}")
     utils.logger.info(f"CHUNK_URI: {env_values['CHUNK_URI']}")
-    utils.logger.info(f"PARTICIPANT_SCOPE: {env_values['PARTICIPANT_SCOPE']}")
     utils.logger.info(f"SITE_DISPLAY_NAME: {env_values['SITE_DISPLAY_NAME']}")
 
     try:
         merge.MergeProcessor.extract_chunk(
             source_uri=env_values['SOURCE_URI'],
             chunk_uri=env_values['CHUNK_URI'],
-            participant_scope=env_values['PARTICIPANT_SCOPE'],
             # Empty env var -> None (no stamping); set only for person.
             site_display_name=env_values['SITE_DISPLAY_NAME'] or None,
         )

--- a/core/jobs/extract_participant_chunk_job.py
+++ b/core/jobs/extract_participant_chunk_job.py
@@ -12,7 +12,6 @@ Required Environment Variables:
     PARTICIPANT_SCOPE: "ALL" for the whole table, otherwise a path to a parquet of participant ids
 
 Optional Environment Variables:
-    PERSON_ID_COLUMN: Column matched against the id set when scope != "ALL" (default "person_id")
     SITE_DISPLAY_NAME: Source site name; when set (person only), stamps care_site_id with its hash
 
 Exit Codes:
@@ -24,7 +23,6 @@ import os
 import sys
 import traceback
 
-import core.constants as constants
 import core.merge as merge
 import core.utils as utils
 
@@ -47,9 +45,6 @@ def validate_env_vars() -> dict[str, str]:
         utils.logger.error(f"Missing required environment variables: {', '.join(missing_vars)}")
         sys.exit(1)
 
-    # Optional: person_id column used only when subsetting by participant scope
-    env_values['PERSON_ID_COLUMN'] = os.getenv('PERSON_ID_COLUMN', constants.DEFAULT_PERSON_ID_COLUMN)
-
     # Optional: site name used to stamp care_site_id (person table only).
     env_values['SITE_DISPLAY_NAME'] = os.getenv('SITE_DISPLAY_NAME', '')
 
@@ -69,7 +64,6 @@ def main():
     utils.logger.info(f"SOURCE_URI: {env_values['SOURCE_URI']}")
     utils.logger.info(f"CHUNK_URI: {env_values['CHUNK_URI']}")
     utils.logger.info(f"PARTICIPANT_SCOPE: {env_values['PARTICIPANT_SCOPE']}")
-    utils.logger.info(f"PERSON_ID_COLUMN: {env_values['PERSON_ID_COLUMN']}")
     utils.logger.info(f"SITE_DISPLAY_NAME: {env_values['SITE_DISPLAY_NAME']}")
 
     try:
@@ -77,7 +71,6 @@ def main():
             source_uri=env_values['SOURCE_URI'],
             chunk_uri=env_values['CHUNK_URI'],
             participant_scope=env_values['PARTICIPANT_SCOPE'],
-            person_id_column=env_values['PERSON_ID_COLUMN'],
             # Empty env var -> None (no stamping); set only for person.
             site_display_name=env_values['SITE_DISPLAY_NAME'] or None,
         )

--- a/core/jobs/extract_participant_chunk_job.py
+++ b/core/jobs/extract_participant_chunk_job.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Cloud Run Job entry point for extracting a (group x table) chunk from a source delivery.
+
+Copies one source table into a provenance-named chunk file in the shared per-table
+merge staging area. For v1 the participant scope is always "ALL" (whole table); a
+participant-id subset (v2) is supported by pointing PARTICIPANT_SCOPE at a parquet of Connect IDs.
+
+Required Environment Variables:
+    SOURCE_URI: Path to the source delivery's table parquet (e.g. .../converted_files/<table>.parquet)
+    CHUNK_URI: Destination chunk parquet path in the staging area
+    PARTICIPANT_SCOPE: "ALL" for the whole table, otherwise a path to a parquet of participant ids
+
+Optional Environment Variables:
+    PERSON_ID_COLUMN: Column matched against the id set when scope != "ALL" (default "person_id")
+
+Exit Codes:
+    0: Success
+    1: Failure
+"""
+
+import os
+import sys
+import traceback
+
+import core.constants as constants
+import core.merge as merge
+import core.utils as utils
+
+
+def validate_env_vars() -> dict[str, str]:
+    """Validate and return required environment variables."""
+    required_vars = ['SOURCE_URI', 'CHUNK_URI', 'PARTICIPANT_SCOPE']
+
+    env_values = {}
+    missing_vars = []
+
+    for var in required_vars:
+        value = os.getenv(var)
+        if not value:
+            missing_vars.append(var)
+        else:
+            env_values[var] = value
+
+    if missing_vars:
+        utils.logger.error(f"Missing required environment variables: {', '.join(missing_vars)}")
+        sys.exit(1)
+
+    # Optional: person_id column used only when subsetting by participant scope
+    env_values['PERSON_ID_COLUMN'] = os.getenv('PERSON_ID_COLUMN', constants.DEFAULT_PERSON_ID_COLUMN)
+
+    return env_values
+
+
+def main():
+    """Main entry point for extract_participant_chunk job."""
+    utils.logger.info("=" * 80)
+    utils.logger.info("Cloud Run Job: Extract Participant Chunk - Starting")
+    utils.logger.info("=" * 80)
+    utils.logger.info(f"PID: {os.getpid()}")
+    utils.logger.info(f"Working directory: {os.getcwd()}")
+
+    env_values = validate_env_vars()
+
+    utils.logger.info(f"SOURCE_URI: {env_values['SOURCE_URI']}")
+    utils.logger.info(f"CHUNK_URI: {env_values['CHUNK_URI']}")
+    utils.logger.info(f"PARTICIPANT_SCOPE: {env_values['PARTICIPANT_SCOPE']}")
+    utils.logger.info(f"PERSON_ID_COLUMN: {env_values['PERSON_ID_COLUMN']}")
+
+    try:
+        merge.MergeProcessor.extract_chunk(
+            source_uri=env_values['SOURCE_URI'],
+            chunk_uri=env_values['CHUNK_URI'],
+            participant_scope=env_values['PARTICIPANT_SCOPE'],
+            person_id_column=env_values['PERSON_ID_COLUMN'],
+        )
+
+        utils.logger.info("=" * 80)
+        utils.logger.info("Cloud Run Job: Extract Participant Chunk - SUCCESS")
+        utils.logger.info("=" * 80)
+        sys.exit(0)
+
+    except Exception as e:
+        utils.logger.error("=" * 80)
+        utils.logger.error("Cloud Run Job: Extract Participant Chunk - FAILED")
+        utils.logger.error("=" * 80)
+        utils.logger.error(f"Error: {str(e)}")
+        utils.logger.error(f"Traceback:\n{traceback.format_exc()}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/core/jobs/extract_participant_chunk_job.py
+++ b/core/jobs/extract_participant_chunk_job.py
@@ -2,8 +2,7 @@
 """
 Cloud Run Job entry point for extracting a (group x table) chunk from a source delivery.
 
-Copies one source table into a provenance-named chunk file in the shared per-table
-merge staging area.
+Copies one source table into a provenance-named chunk file in the shared per-table merge staging area.
 
 Required Environment Variables:
     SOURCE_URI: Path to the source delivery's table parquet (e.g. .../converted_files/<table>.parquet)

--- a/core/jobs/reconcile_chunks_job.py
+++ b/core/jobs/reconcile_chunks_job.py
@@ -2,10 +2,6 @@
 """
 Cloud Run Job entry point for reconciling per-table merge chunks into one merged table.
 
-Unions every chunk file matching CHUNK_GLOB into a single merged parquet at OUTPUT_URI
-(which lives in converted_files/, outside the chunk folder). union_by_name defends
-against benign column-order/schema drift across sites.
-
 Required Environment Variables:
     CHUNK_GLOB: Glob over the per-table staging folder (e.g. .../merge_chunks/<table>/*.parquet)
     OUTPUT_URI: Destination for the reconciled table (e.g. .../converted_files/<table>.parquet)

--- a/core/jobs/reconcile_chunks_job.py
+++ b/core/jobs/reconcile_chunks_job.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Cloud Run Job entry point for reconciling per-table merge chunks into one merged table.
+
+Unions every chunk file matching CHUNK_GLOB into a single merged parquet at OUTPUT_URI
+(which lives in converted_files/, outside the chunk folder). union_by_name defends
+against benign column-order/schema drift across sites.
+
+Required Environment Variables:
+    CHUNK_GLOB: Glob over the per-table staging folder (e.g. .../merge_chunks/<table>/*.parquet)
+    OUTPUT_URI: Destination for the reconciled table (e.g. .../converted_files/<table>.parquet)
+
+Exit Codes:
+    0: Success
+    1: Failure
+"""
+
+import os
+import sys
+import traceback
+
+import core.merge as merge
+import core.utils as utils
+
+
+def validate_env_vars() -> dict[str, str]:
+    """Validate and return required environment variables."""
+    required_vars = ['CHUNK_GLOB', 'OUTPUT_URI']
+
+    env_values = {}
+    missing_vars = []
+
+    for var in required_vars:
+        value = os.getenv(var)
+        if not value:
+            missing_vars.append(var)
+        else:
+            env_values[var] = value
+
+    if missing_vars:
+        utils.logger.error(f"Missing required environment variables: {', '.join(missing_vars)}")
+        sys.exit(1)
+
+    return env_values
+
+
+def main():
+    """Main entry point for reconcile_chunks job."""
+    utils.logger.info("=" * 80)
+    utils.logger.info("Cloud Run Job: Reconcile Chunks - Starting")
+    utils.logger.info("=" * 80)
+    utils.logger.info(f"PID: {os.getpid()}")
+    utils.logger.info(f"Working directory: {os.getcwd()}")
+
+    env_values = validate_env_vars()
+
+    utils.logger.info(f"CHUNK_GLOB: {env_values['CHUNK_GLOB']}")
+    utils.logger.info(f"OUTPUT_URI: {env_values['OUTPUT_URI']}")
+
+    try:
+        merge.MergeProcessor.reconcile_chunks(
+            chunk_glob=env_values['CHUNK_GLOB'],
+            output_uri=env_values['OUTPUT_URI'],
+        )
+
+        utils.logger.info("=" * 80)
+        utils.logger.info("Cloud Run Job: Reconcile Chunks - SUCCESS")
+        utils.logger.info("=" * 80)
+        sys.exit(0)
+
+    except Exception as e:
+        utils.logger.error("=" * 80)
+        utils.logger.error("Cloud Run Job: Reconcile Chunks - FAILED")
+        utils.logger.error("=" * 80)
+        utils.logger.error(f"Error: {str(e)}")
+        utils.logger.error(f"Traceback:\n{traceback.format_exc()}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/core/merge.py
+++ b/core/merge.py
@@ -34,7 +34,7 @@ class MergeProcessor:
             chunk_uri: Path to the destination chunk parquet in the staging area.
             participant_scope: constants.PARTICIPANT_SCOPE_ALL for the whole table, otherwise a
                 path to a parquet file with an `id` column of participant ids to keep.
-            person_id_column: Column TRY_CAST to BIGINT and matched against the id set. Only used
+            person_id_column: Column matched against the id set. Only used
                 when participant_scope is not PARTICIPANT_SCOPE_ALL.
         """
         source = storage.get_uri(source_uri)

--- a/core/merge.py
+++ b/core/merge.py
@@ -1,15 +1,21 @@
 """
 EHR PR2 merge-pipeline helpers.
 
-extract_chunk: pull one (group x table) slice out of a source delivery into a
-provenance-named chunk file in the shared per-table staging area. For v1 the
-participant scope is always "ALL" (whole table, no WHERE). A participant-id
-subset (v2) is supported by pointing PARTICIPANT_SCOPE at a parquet of ids.
+extract_chunk: copy one (group x table) slice from a source delivery into a
+provenance-named chunk file. v1 scope is "ALL" (whole table); a participant-id
+subset (v2) points PARTICIPANT_SCOPE at a parquet of ids. For person, stamps
+care_site_id = hash_care_site_id(site) to record each patient's origin site.
 
-reconcile_chunks: union all chunk files for a table into a single merged
-converted_files/<table>.parquet. union_by_name defends against benign
-column-order/schema drift across sites (all were normalized to the same CDM).
+reconcile_chunks: union a table's chunk files into converted_files/<table>.parquet
+(union_by_name tolerates column-order/schema drift across sites).
+
+build_care_site: write converted_files/care_site.parquet mapping each merged
+site's hashed care_site_id to its name. Not carried from deliveries; built from
+the merged site set to match the person.care_site_id stamps.
 """
+
+import hashlib
+from typing import Optional
 
 import core.constants as constants
 import core.utils as utils
@@ -20,11 +26,31 @@ class MergeProcessor:
     """Extract per-group table chunks and reconcile them into merged per-table files."""
 
     @staticmethod
+    def hash_care_site_id(site_display_name: str) -> int:
+        """Stable, deterministic signed-64-bit care_site_id for a site name."""
+        digest = hashlib.sha256(site_display_name.encode("utf-8")).digest()
+        value = int.from_bytes(digest[:8], "big") & 0x7FFFFFFFFFFFFFFF
+        return value or 1
+
+    @staticmethod
+    def _extract_select_list(site_display_name: Optional[str]) -> str:
+        """
+        Extract SELECT list: "*", or "* REPLACE(...)" overwriting care_site_id with the
+        site's hashed id when site_display_name is given (person only; care_site_id is a
+        standard person column so REPLACE always resolves).
+        """
+        if site_display_name is None:
+            return "*"
+        care_site_id = MergeProcessor.hash_care_site_id(site_display_name)
+        return f"* REPLACE (CAST({care_site_id} AS BIGINT) AS care_site_id)"
+
+    @staticmethod
     def generate_extract_chunk_sql(
         source_uri: str,
         chunk_uri: str,
         participant_scope: str,
         person_id_column: str = constants.DEFAULT_PERSON_ID_COLUMN,
+        site_display_name: Optional[str] = None,
     ) -> str:
         """
         Generate SQL to copy one source table (optionally subset by participant) into a chunk file.
@@ -36,14 +62,17 @@ class MergeProcessor:
                 path to a parquet file with an `id` column of participant ids to keep.
             person_id_column: Column matched against the id set. Only used
                 when participant_scope is not PARTICIPANT_SCOPE_ALL.
+            site_display_name: Source site name; when set (person only), stamps care_site_id
+                with its hash to record each patient's origin site.
         """
         source = storage.get_uri(source_uri)
         chunk = storage.get_uri(chunk_uri)
+        select_list = MergeProcessor._extract_select_list(site_display_name)
 
         if participant_scope == constants.PARTICIPANT_SCOPE_ALL:
             return f"""
             COPY (
-                SELECT * FROM read_parquet('{source}')
+                SELECT {select_list} FROM read_parquet('{source}')
             ) TO '{chunk}' {constants.DUCKDB_FORMAT_STRING}
             """
 
@@ -52,7 +81,7 @@ class MergeProcessor:
         ids = storage.get_uri(participant_scope)
         return f"""
         COPY (
-            SELECT * FROM read_parquet('{source}')
+            SELECT {select_list} FROM read_parquet('{source}')
             WHERE {person_id_column} IN (
                 SELECT id FROM read_parquet('{ids}')
             )
@@ -65,12 +94,67 @@ class MergeProcessor:
         chunk_uri: str,
         participant_scope: str,
         person_id_column: str = constants.DEFAULT_PERSON_ID_COLUMN,
+        site_display_name: Optional[str] = None,
     ) -> None:
         """Execute the chunk extraction. Writes chunk_uri outside the source directory."""
         sql = MergeProcessor.generate_extract_chunk_sql(
-            source_uri, chunk_uri, participant_scope, person_id_column
+            source_uri, chunk_uri, participant_scope, person_id_column, site_display_name
         )
         utils.execute_duckdb_sql(sql, f"Unable to extract participant chunk to {chunk_uri}")
+
+    @staticmethod
+    def generate_build_care_site_sql(
+        output_uri: str, site_display_names: list[str], cdm_version: str
+    ) -> str:
+        """
+        Build care_site: one row per site, care_site_id = hash(name), care_site_name =
+        name, other columns typed NULL. Column order/types from the OMOP care_site schema
+        so the parquet loads to BQ cleanly. Duplicate names collapse to one row (PK).
+        """
+        # De-dup, preserving first-seen order (distinct sites -> distinct ids).
+        unique_names = list(dict.fromkeys(site_display_names))
+        if not unique_names:
+            raise ValueError("Cannot build care_site table: no site names provided")
+
+        columns = utils.get_table_schema("care_site", cdm_version)["care_site"]["columns"]
+        output = storage.get_uri(output_uri)
+
+        rows = []
+        for name in unique_names:
+            care_site_id = MergeProcessor.hash_care_site_id(name)
+            escaped_name = name.replace("'", "''")
+            value_exprs = []
+            for column_name in columns:
+                if column_name == "care_site_id":
+                    value_exprs.append(str(care_site_id))
+                elif column_name == "care_site_name":
+                    value_exprs.append(f"'{escaped_name}'")
+                else:
+                    value_exprs.append("NULL")
+            rows.append(f"({', '.join(value_exprs)})")
+
+        projection = ",\n                ".join(
+            f"CAST({column_name} AS {column_info['type']}) AS {column_name}"
+            for column_name, column_info in columns.items()
+        )
+        column_list = ", ".join(columns.keys())
+        values = ",\n                ".join(rows)
+
+        return f"""
+        COPY (
+            SELECT
+                {projection}
+            FROM (VALUES
+                {values}
+            ) AS t({column_list})
+        ) TO '{output}' {constants.DUCKDB_FORMAT_STRING}
+        """
+
+    @staticmethod
+    def build_care_site(output_uri: str, site_display_names: list[str], cdm_version: str) -> None:
+        """Write the merged instance's care_site table from the set of merged site names."""
+        sql = MergeProcessor.generate_build_care_site_sql(output_uri, site_display_names, cdm_version)
+        utils.execute_duckdb_sql(sql, f"Unable to build care_site table at {output_uri}")
 
     @staticmethod
     def generate_reconcile_chunks_sql(chunk_glob: str, output_uri: str) -> str:

--- a/core/merge.py
+++ b/core/merge.py
@@ -1,0 +1,98 @@
+"""
+EHR PR2 merge-pipeline helpers.
+
+extract_chunk: pull one (group x table) slice out of a source delivery into a
+provenance-named chunk file in the shared per-table staging area. For v1 the
+participant scope is always "ALL" (whole table, no WHERE). A participant-id
+subset (v2) is supported by pointing PARTICIPANT_SCOPE at a parquet of ids.
+
+reconcile_chunks: union all chunk files for a table into a single merged
+converted_files/<table>.parquet. union_by_name defends against benign
+column-order/schema drift across sites (all were normalized to the same CDM).
+"""
+
+import core.constants as constants
+import core.utils as utils
+from core.storage_backend import storage
+
+
+class MergeProcessor:
+    """Extract per-group table chunks and reconcile them into merged per-table files."""
+
+    @staticmethod
+    def generate_extract_chunk_sql(
+        source_uri: str,
+        chunk_uri: str,
+        participant_scope: str,
+        person_id_column: str = constants.DEFAULT_PERSON_ID_COLUMN,
+    ) -> str:
+        """
+        Generate SQL to copy one source table (optionally subset by participant) into a chunk file.
+
+        Args:
+            source_uri: Path to the source delivery's table parquet (any/no scheme; normalized).
+            chunk_uri: Path to the destination chunk parquet in the staging area.
+            participant_scope: constants.PARTICIPANT_SCOPE_ALL for the whole table, otherwise a
+                path to a parquet file with an `id` column of participant ids to keep.
+            person_id_column: Column TRY_CAST to BIGINT and matched against the id set. Only used
+                when participant_scope is not PARTICIPANT_SCOPE_ALL.
+        """
+        source = storage.get_uri(source_uri)
+        chunk = storage.get_uri(chunk_uri)
+
+        if participant_scope == constants.PARTICIPANT_SCOPE_ALL:
+            return f"""
+            COPY (
+                SELECT * FROM read_parquet('{source}')
+            ) TO '{chunk}' {constants.DUCKDB_FORMAT_STRING}
+            """
+
+        # v2 path will eventually subset to a pre-defined Connect ID list;
+        # for v1, get all IDs and then filter later.
+        ids = storage.get_uri(participant_scope)
+        return f"""
+        COPY (
+            SELECT * FROM read_parquet('{source}')
+            WHERE {person_id_column} IN (
+                SELECT id FROM read_parquet('{ids}')
+            )
+        ) TO '{chunk}' {constants.DUCKDB_FORMAT_STRING}
+        """
+
+    @staticmethod
+    def extract_chunk(
+        source_uri: str,
+        chunk_uri: str,
+        participant_scope: str,
+        person_id_column: str = constants.DEFAULT_PERSON_ID_COLUMN,
+    ) -> None:
+        """Execute the chunk extraction. Writes chunk_uri outside the source directory."""
+        sql = MergeProcessor.generate_extract_chunk_sql(
+            source_uri, chunk_uri, participant_scope, person_id_column
+        )
+        utils.execute_duckdb_sql(sql, f"Unable to extract participant chunk to {chunk_uri}")
+
+    @staticmethod
+    def generate_reconcile_chunks_sql(chunk_glob: str, output_uri: str) -> str:
+        """
+        Generate SQL to union all chunk files matching a glob into one merged parquet.
+
+        Args:
+            chunk_glob: Glob over the per-table staging folder (e.g. .../merge_chunks/<table>/*.parquet).
+            output_uri: Destination for the reconciled table. MUST live outside the chunk folder
+                (in converted_files/) so the read glob never re-reads its own output and downstream
+                table-name parsing works.
+        """
+        chunks = storage.get_uri(chunk_glob)
+        output = storage.get_uri(output_uri)
+        return f"""
+        COPY (
+            SELECT * FROM read_parquet('{chunks}', union_by_name=true)
+        ) TO '{output}' {constants.DUCKDB_FORMAT_STRING}
+        """
+
+    @staticmethod
+    def reconcile_chunks(chunk_glob: str, output_uri: str) -> None:
+        """Execute the reconciliation. Raises if the glob matches no chunk files."""
+        sql = MergeProcessor.generate_reconcile_chunks_sql(chunk_glob, output_uri)
+        utils.execute_duckdb_sql(sql, f"Unable to reconcile chunks into {output_uri}")

--- a/core/merge.py
+++ b/core/merge.py
@@ -13,6 +13,7 @@ class MergeProcessor:
     def hash_care_site_id(site_display_name: str) -> int:
         """Stable, deterministic signed-64-bit care_site_id for a site name."""
         digest = hashlib.sha256(site_display_name.encode("utf-8")).digest()
+        # Keep resulting care_site_id within 64 int space
         value = int.from_bytes(digest[:8], "big") & 0x7FFFFFFFFFFFFFFF
         return value or 1
 
@@ -68,9 +69,8 @@ class MergeProcessor:
         output_uri: str, site_display_names: list[str], cdm_version: str
     ) -> str:
         """
-        Build care_site: one row per site, care_site_id = hash(name), care_site_name =
-        name, other columns typed NULL. Column order/types from the OMOP care_site schema
-        so the parquet loads to BQ cleanly. Duplicate names collapse to one row (PK).
+        Build care_site: one row per site, care_site_id = hash(name), care_site_name = name, everything else is NULL.
+        Column order/types from the OMOP care_site schema.
         """
         # De-dup, preserving first-seen order (distinct sites -> distinct ids).
         unique_names = list(dict.fromkeys(site_display_names))
@@ -129,10 +129,9 @@ class MergeProcessor:
         """
         Generate SQL for the merged instance's de novo one-row cdm_source.
 
-        Fixed Connect metadata (constants) + site_count in the description. source_release_date
-        is the LATEST across the sites' cdm_source files (falling back to cdm_release_date if
-        none). cdm_release_date is the merge run date; cdm_version_concept_id is derived from
-        cdm_version. Column order/types mirror the single-site cdm_source.
+        Fixed Connect metadata (constants) + site_count in the description. 
+        source_release_date is the LATEST across the sites' cdm_source files (falling back to cdm_release_date if none). 
+        cdm_release_date is the merge run date; cdm_version_concept_id is derived from cdm_version.
         """
         if not source_cdm_source_uris:
             raise ValueError("Cannot build cdm_source: no source cdm_source files provided")

--- a/core/merge.py
+++ b/core/merge.py
@@ -1,19 +1,3 @@
-"""
-EHR PR2 merge-pipeline helpers.
-
-extract_chunk: copy one (group x table) slice from a source delivery into a
-provenance-named chunk file. v1 scope is "ALL" (whole table); a participant-id
-subset (v2) points PARTICIPANT_SCOPE at a parquet of ids. For person, stamps
-care_site_id = hash_care_site_id(site) to record each patient's origin site.
-
-reconcile_chunks: union a table's chunk files into converted_files/<table>.parquet
-(union_by_name tolerates column-order/schema drift across sites).
-
-build_care_site: write converted_files/care_site.parquet mapping each merged
-site's hashed care_site_id to its name. Not carried from deliveries; built from
-the merged site set to match the person.care_site_id stamps.
-"""
-
 import hashlib
 from typing import Optional
 
@@ -48,17 +32,14 @@ class MergeProcessor:
     def generate_extract_chunk_sql(
         source_uri: str,
         chunk_uri: str,
-        participant_scope: str,
         site_display_name: Optional[str] = None,
     ) -> str:
         """
-        Generate SQL to copy one source table (optionally subset by participant) into a chunk file.
+        Generate SQL to copy one source table into a provenance-named chunk file.
 
         Args:
             source_uri: Path to the source delivery's table parquet (any/no scheme; normalized).
             chunk_uri: Path to the destination chunk parquet in the staging area.
-            participant_scope: constants.PARTICIPANT_SCOPE_ALL for the whole table, otherwise a
-                path to a parquet file with an `id` column of participant ids to keep.
             site_display_name: Source site name; when set (person only), stamps care_site_id
                 with its hash to record each patient's origin site.
         """
@@ -66,22 +47,9 @@ class MergeProcessor:
         chunk = storage.get_uri(chunk_uri)
         select_list = MergeProcessor._extract_select_list(site_display_name)
 
-        if participant_scope == constants.PARTICIPANT_SCOPE_ALL:
-            return f"""
-            COPY (
-                SELECT {select_list} FROM read_parquet('{source}')
-            ) TO '{chunk}' {constants.DUCKDB_FORMAT_STRING}
-            """
-
-        # v2 path will eventually subset to a pre-defined Connect ID list;
-        # for v1, get all IDs and then filter later.
-        ids = storage.get_uri(participant_scope)
         return f"""
         COPY (
             SELECT {select_list} FROM read_parquet('{source}')
-            WHERE person_id IN (
-                SELECT id FROM read_parquet('{ids}')
-            )
         ) TO '{chunk}' {constants.DUCKDB_FORMAT_STRING}
         """
 
@@ -89,14 +57,11 @@ class MergeProcessor:
     def extract_chunk(
         source_uri: str,
         chunk_uri: str,
-        participant_scope: str,
         site_display_name: Optional[str] = None,
     ) -> None:
         """Execute the chunk extraction. Writes chunk_uri outside the source directory."""
-        sql = MergeProcessor.generate_extract_chunk_sql(
-            source_uri, chunk_uri, participant_scope, site_display_name
-        )
-        utils.execute_duckdb_sql(sql, f"Unable to extract participant chunk to {chunk_uri}")
+        sql = MergeProcessor.generate_extract_chunk_sql(source_uri, chunk_uri, site_display_name)
+        utils.execute_duckdb_sql(sql, f"Unable to extract chunk to {chunk_uri}")
 
     @staticmethod
     def generate_build_care_site_sql(

--- a/core/merge.py
+++ b/core/merge.py
@@ -157,6 +157,66 @@ class MergeProcessor:
         utils.execute_duckdb_sql(sql, f"Unable to build care_site table at {output_uri}")
 
     @staticmethod
+    def generate_build_cdm_source_sql(
+        output_uri: str,
+        source_cdm_source_uris: list[str],
+        site_count: int,
+        cdm_version: str,
+        vocabulary_version: str,
+        cdm_release_date: str,
+    ) -> str:
+        """
+        Generate SQL for the merged instance's de novo one-row cdm_source.
+
+        Fixed Connect metadata (constants) + site_count in the description. source_release_date
+        is the LATEST across the sites' cdm_source files (falling back to cdm_release_date if
+        none). cdm_release_date is the merge run date; cdm_version_concept_id is derived from
+        cdm_version. Column order/types mirror the single-site cdm_source.
+        """
+        if not source_cdm_source_uris:
+            raise ValueError("Cannot build cdm_source: no source cdm_source files provided")
+
+        output = storage.get_uri(output_uri)
+        uri_list = ", ".join(f"'{storage.get_uri(uri)}'" for uri in source_cdm_source_uris)
+        concept_id = utils.get_cdm_version_concept_id(cdm_version)
+        description = constants.MERGE_CDM_SOURCE_DESCRIPTION.format(site_count=site_count)
+
+        return f"""
+        COPY (
+            SELECT
+                '{constants.MERGE_CDM_SOURCE_NAME}' AS cdm_source_name,
+                '{constants.MERGE_CDM_SOURCE_ABBREVIATION}' AS cdm_source_abbreviation,
+                '{constants.MERGE_CDM_HOLDER}' AS cdm_holder,
+                '{description}' AS source_description,
+                '{constants.MERGE_SOURCE_DOCUMENTATION_REFERENCE}' AS source_documentation_reference,
+                '{constants.MERGE_CDM_ETL_REFERENCE}' AS cdm_etl_reference,
+                COALESCE(
+                    (SELECT MAX(source_release_date) FROM read_parquet([{uri_list}], union_by_name=true)),
+                    CAST('{cdm_release_date}' AS DATE)
+                ) AS source_release_date,
+                CAST('{cdm_release_date}' AS DATE) AS cdm_release_date,
+                '{cdm_version}' AS cdm_version,
+                {concept_id} AS cdm_version_concept_id,
+                '{vocabulary_version}' AS vocabulary_version
+        ) TO '{output}' {constants.DUCKDB_FORMAT_STRING}
+        """
+
+    @staticmethod
+    def build_cdm_source(
+        output_uri: str,
+        source_cdm_source_uris: list[str],
+        site_count: int,
+        cdm_version: str,
+        vocabulary_version: str,
+        cdm_release_date: str,
+    ) -> None:
+        """Write the merged instance's de novo cdm_source parquet."""
+        sql = MergeProcessor.generate_build_cdm_source_sql(
+            output_uri, source_cdm_source_uris, site_count, cdm_version, vocabulary_version, cdm_release_date
+        )
+        utils.execute_duckdb_sql(sql, f"Unable to build cdm_source at {output_uri}")
+
+    @staticmethod
     def generate_reconcile_chunks_sql(chunk_glob: str, output_uri: str) -> str:
         """
         Generate SQL to union all chunk files matching a glob into one merged parquet.

--- a/core/merge.py
+++ b/core/merge.py
@@ -49,7 +49,6 @@ class MergeProcessor:
         source_uri: str,
         chunk_uri: str,
         participant_scope: str,
-        person_id_column: str = constants.DEFAULT_PERSON_ID_COLUMN,
         site_display_name: Optional[str] = None,
     ) -> str:
         """
@@ -60,8 +59,6 @@ class MergeProcessor:
             chunk_uri: Path to the destination chunk parquet in the staging area.
             participant_scope: constants.PARTICIPANT_SCOPE_ALL for the whole table, otherwise a
                 path to a parquet file with an `id` column of participant ids to keep.
-            person_id_column: Column matched against the id set. Only used
-                when participant_scope is not PARTICIPANT_SCOPE_ALL.
             site_display_name: Source site name; when set (person only), stamps care_site_id
                 with its hash to record each patient's origin site.
         """
@@ -82,7 +79,7 @@ class MergeProcessor:
         return f"""
         COPY (
             SELECT {select_list} FROM read_parquet('{source}')
-            WHERE {person_id_column} IN (
+            WHERE person_id IN (
                 SELECT id FROM read_parquet('{ids}')
             )
         ) TO '{chunk}' {constants.DUCKDB_FORMAT_STRING}
@@ -93,12 +90,11 @@ class MergeProcessor:
         source_uri: str,
         chunk_uri: str,
         participant_scope: str,
-        person_id_column: str = constants.DEFAULT_PERSON_ID_COLUMN,
         site_display_name: Optional[str] = None,
     ) -> None:
         """Execute the chunk extraction. Writes chunk_uri outside the source directory."""
         sql = MergeProcessor.generate_extract_chunk_sql(
-            source_uri, chunk_uri, participant_scope, person_id_column, site_display_name
+            source_uri, chunk_uri, participant_scope, site_display_name
         )
         utils.execute_duckdb_sql(sql, f"Unable to extract participant chunk to {chunk_uri}")
 

--- a/core/merge_reporting.py
+++ b/core/merge_reporting.py
@@ -1,18 +1,10 @@
-"""
-Report artifacts for a merge run.
-
-Unlike the per-site ReportGenerator (core/reporting.py), which analyzes a single
-delivery's tables, this describes what went INTO a merge: which sites and which
-site deliveries were included, and how many rows each delivery contributed.
-"""
-
 import core.constants as constants
 import core.helpers.report_artifact as report_artifact
 import core.reporting as reporting
 import core.utils as utils
 from core.storage_backend import storage
 
-# Artifact names (kept as constants so tests and downstream reporting can key on them).
+# Artifact names
 SOURCE_SITE_ARTIFACT = "Merge source site"
 SOURCE_DELIVERY_ROW_COUNT_ARTIFACT = "Merge source delivery row count"
 TOTAL_ROW_COUNT_ARTIFACT = "Merge total row count"
@@ -36,12 +28,7 @@ class MergeReporter:
 
     @staticmethod
     def generate_delivery_row_count_sql(chunk_glob: str) -> str:
-        """
-        Count every row a single source delivery contributes to the merge.
-
-        Reads all of that delivery's per-table chunks at once; union_by_name stacks
-        the heterogeneous table schemas so COUNT(*) is the delivery's total input rows.
-        """
+        """Count every row a single source delivery contributes to the merge."""
         glob = storage.get_uri(chunk_glob)
         return f"""
         SELECT COUNT(*) AS row_count

--- a/core/merge_reporting.py
+++ b/core/merge_reporting.py
@@ -1,0 +1,166 @@
+"""
+Report artifacts for a merge run.
+
+Unlike the per-site ReportGenerator (core/reporting.py), which analyzes a single
+delivery's tables, this describes what went INTO a merge: which sites and which
+site deliveries were included, and how many rows each delivery contributed.
+"""
+
+import core.constants as constants
+import core.helpers.report_artifact as report_artifact
+import core.reporting as reporting
+import core.utils as utils
+from core.storage_backend import storage
+
+# Artifact names (kept as constants so tests and downstream reporting can key on them).
+SOURCE_SITE_ARTIFACT = "Merge source site"
+SOURCE_DELIVERY_ROW_COUNT_ARTIFACT = "Merge source delivery row count"
+TOTAL_ROW_COUNT_ARTIFACT = "Merge total row count"
+
+
+class MergeReporter:
+    """Generate provenance report artifacts describing a merge run's inputs."""
+
+    @staticmethod
+    def delivery_chunk_glob(merge_bucket: str, run_date: str, site: str, delivery_date: str) -> str:
+        """
+        Glob matching every table's chunk for one source (site, delivery_date).
+
+        Chunk files are named <table>__<site>__<delivery_date>.parquet under
+        merge_chunks/<table>/, so the leading */ matches each per-table subfolder.
+        """
+        return (
+            f"{merge_bucket}/{run_date}/{constants.ArtifactPaths.MERGE_CHUNKS.value}"
+            f"*/*__{site}__{delivery_date}{constants.PARQUET}"
+        )
+
+    @staticmethod
+    def generate_delivery_row_count_sql(chunk_glob: str) -> str:
+        """
+        Count every row a single source delivery contributes to the merge.
+
+        Reads all of that delivery's per-table chunks at once; union_by_name stacks
+        the heterogeneous table schemas so COUNT(*) is the delivery's total input rows.
+        """
+        glob = storage.get_uri(chunk_glob)
+        return f"""
+        SELECT COUNT(*) AS row_count
+        FROM read_parquet('{glob}', union_by_name=true)
+        """
+
+    @staticmethod
+    def generate_merge_report(merge_bucket: str, run_date: str, site: str, deliveries: list[dict]) -> None:
+        """
+        Create merge provenance artifacts, then consolidate them into the report CSV.
+
+        Args:
+            merge_bucket: The merged instance's bucket.
+            run_date: The merged instance's delivery_date slot (US/Eastern run date).
+            site: The synthetic merge site_name (used for the report CSV file name).
+            deliveries: The source deliveries in this merge run, each {"site", "delivery_date"}.
+        """
+        MergeReporter._create_source_site_artifacts(merge_bucket, run_date, deliveries)
+        total_rows = MergeReporter._create_source_delivery_row_count_artifacts(merge_bucket, run_date, deliveries)
+        MergeReporter._create_total_row_count_artifact(merge_bucket, run_date, total_rows)
+        MergeReporter._consolidate(merge_bucket, run_date, site)
+
+    @staticmethod
+    def _create_source_site_artifacts(merge_bucket: str, run_date: str, deliveries: list[dict]) -> None:
+        """One artifact per distinct source site included in the merge."""
+        sites = sorted({delivery["site"] for delivery in deliveries})
+        utils.logger.info(f"Creating {len(sites)} merge source site artifact(s)")
+
+        for site in sites:
+            report_artifact.ReportArtifact(
+                delivery_date=run_date,
+                artifact_bucket=merge_bucket,
+                concept_id=0,
+                name=SOURCE_SITE_ARTIFACT,
+                value_as_string=site,
+                value_as_concept_id=0,
+                value_as_number=None,
+            ).save_artifact()
+
+    @staticmethod
+    def _create_source_delivery_row_count_artifacts(merge_bucket: str, run_date: str, deliveries: list[dict]) -> int:
+        """
+        One artifact per source delivery, carrying the rows it contributed to the merge.
+
+        Returns the total rows across all deliveries (the sum of the per-delivery
+        counts), so the caller can emit the merge-wide total without a second pass.
+        """
+        utils.logger.info(f"Creating {len(deliveries)} merge source delivery row-count artifact(s)")
+
+        total_rows = 0
+        for delivery in sorted(deliveries, key=lambda d: (d["site"], d["delivery_date"])):
+            site = delivery["site"]
+            delivery_date = delivery["delivery_date"]
+
+            chunk_glob = MergeReporter.delivery_chunk_glob(merge_bucket, run_date, site, delivery_date)
+            sql = MergeReporter.generate_delivery_row_count_sql(chunk_glob)
+            result = utils.execute_duckdb_sql(
+                sql,
+                f"Unable to count merge input rows for {site} {delivery_date}",
+                return_results=True,
+            )
+            row_count = result[0][0] if result else 0
+            total_rows += row_count
+
+            report_artifact.ReportArtifact(
+                delivery_date=run_date,
+                artifact_bucket=merge_bucket,
+                concept_id=0,
+                name=SOURCE_DELIVERY_ROW_COUNT_ARTIFACT,
+                value_as_string=f"{site}__{delivery_date}",
+                value_as_concept_id=0,
+                value_as_number=float(row_count),
+            ).save_artifact()
+
+        return total_rows
+
+    @staticmethod
+    def _create_total_row_count_artifact(merge_bucket: str, run_date: str, total_rows: int) -> None:
+        """One summary artifact: total rows across every delivery going into the merge."""
+        utils.logger.info(f"Creating merge total row-count artifact: {total_rows} rows")
+
+        report_artifact.ReportArtifact(
+            delivery_date=run_date,
+            artifact_bucket=merge_bucket,
+            concept_id=0,
+            name=TOTAL_ROW_COUNT_ARTIFACT,
+            value_as_string=None,
+            value_as_concept_id=0,
+            value_as_number=float(total_rows),
+        ).save_artifact()
+
+    @staticmethod
+    def _consolidate(merge_bucket: str, run_date: str, site: str) -> None:
+        """
+        Union the merge report parts into one CSV.
+
+        Mirrors ReportGenerator._consolidate_report_files (reusing its consolidation
+        SQL) but omits the per-site Connect participant summary, which is not
+        meaningful for a merged instance.
+        """
+        report_tmp_dir = f"{run_date}/{constants.ArtifactPaths.REPORT_TMP.value}"
+        tmp_files = utils.list_files(merge_bucket, report_tmp_dir, constants.PARQUET)
+
+        if len(tmp_files) == 0:
+            utils.logger.warning("No merge report artifacts found to consolidate")
+            return
+
+        file_paths = [
+            storage.get_uri(f"{merge_bucket}/{report_tmp_dir}{file}")
+            for file in tmp_files
+        ]
+        select_statement = " UNION ALL ".join(
+            f"SELECT * FROM read_parquet('{path}')"
+            for path in file_paths
+        )
+
+        output_path = storage.get_uri(
+            f"{merge_bucket}/{run_date}/{constants.ArtifactPaths.REPORT.value}"
+            f"delivery_report_{site}_{run_date}{constants.CSV}"
+        )
+        sql = reporting.ReportGenerator.generate_report_consolidation_sql(select_statement, output_path)
+        utils.execute_duckdb_sql(sql, "Unable to consolidate merge report artifacts")

--- a/core/omop_client.py
+++ b/core/omop_client.py
@@ -254,6 +254,44 @@ class OMOPClient:
             raise Exception(f"Unable to generate {table_name} derived data from harmonized files: {str(e)}") from e
 
     @staticmethod
+    def get_delivery_cdm_version(bucket: str, delivery_date: str) -> dict:
+        """
+        Read the CDM and vocabulary versions a delivery was standardized to.
+
+        Reads the single-row processed cdm_source.parquet in converted_files/. This is the
+        authoritative version for a PROCESSED delivery (the site-delivered version in
+        site_config / the BQ log records the delivered, not standardized, version).
+
+        Args:
+            bucket: Bucket/directory of the source delivery.
+            delivery_date: Delivery date directory component (YYYY-MM-DD).
+
+        Returns:
+            {"cdm_version": <str|None>, "vocabulary_version": <str|None>}. Both None if the
+            cdm_source file has no rows.
+        """
+        cdm_source_path = f"{bucket}/{delivery_date}/{constants.ArtifactPaths.CONVERTED_FILES.value}cdm_source{constants.PARQUET}"
+        cdm_source_uri = storage.get_uri(cdm_source_path)
+
+        sql = OMOPClient.generate_get_delivery_cdm_version_sql(cdm_source_uri)
+        result = utils.execute_duckdb_sql(
+            sql, f"Unable to read cdm_version from {cdm_source_uri}", return_results=True
+        )
+
+        if result and len(result) > 0:
+            return {"cdm_version": result[0][0], "vocabulary_version": result[0][1]}
+        return {"cdm_version": None, "vocabulary_version": None}
+
+    @staticmethod
+    def generate_get_delivery_cdm_version_sql(cdm_source_uri: str) -> str:
+        """Generate SQL to read cdm_version and vocabulary_version from a cdm_source parquet."""
+        return f"""
+            SELECT cdm_version, vocabulary_version
+            FROM read_parquet('{cdm_source_uri}')
+            LIMIT 1
+        """
+
+    @staticmethod
     def generate_upgrade_file_sql(upgrade_script: str, normalized_file_path: str) -> str:
         """
         Generate SQL to upgrade an OMOP CDM table file.

--- a/core/omop_client.py
+++ b/core/omop_client.py
@@ -100,8 +100,8 @@ class OMOPClient:
 
         Checks if site delivered cdm_source file and populates it with metadata if needed:
         - If file exists with exactly one row: keep the site-delivered descriptive columns but
-          overwrite the pipeline-controlled fields: source_release_date (keeps site value if
-          parseable, else delivery_date), cdm_release_date (=delivery_date), and
+          overwrite the pipeline-controlled fields: source_release_date and cdm_release_date
+          (keep the site value if parseable, else fall back to delivery_date) and
           cdm_version / cdm_version_concept_id / vocabulary_version (=the target the data was
           standardized to). Every other site-delivered column passes through unchanged.
         - If file exists with multiple rows: treat as if no rows were delivered and populate
@@ -148,7 +148,7 @@ class OMOPClient:
             populate_sql = OMOPClient.generate_populate_cdm_source_sql(cdm_source_data, cdm_source_uri)
             utils.execute_duckdb_sql(populate_sql, "Unable to populate cdm_source file")
         elif row_count == 1:
-            utils.logger.info("cdm_source file has 1 row; rewriting release dates and overwriting cdm/vocab versions to target")
+            utils.logger.info("cdm_source file has 1 row; keeping site release dates (fallback to delivery_date) and overwriting cdm/vocab versions to target")
             rewrite_sql = OMOPClient.generate_rewrite_cdm_source_sql(
                 cdm_source_uri,
                 date_format,
@@ -382,8 +382,8 @@ class OMOPClient:
         """
         Rewrite a site-delivered 1-row cdm_source in place, overwriting pipeline-controlled fields:
 
-        - source_release_date: site value if parseable (date_format or direct cast), else delivery_date.
-        - cdm_release_date: always delivery_date.
+        - source_release_date / cdm_release_date: keep the site value if parseable (date_format
+          or direct cast), else fall back to delivery_date.
         - cdm_version / cdm_version_concept_id / vocabulary_version: the target the pipeline
           standardized the data to (site's self-reported values are discarded).
 
@@ -396,12 +396,19 @@ class OMOPClient:
             date_format=date_format,
             datetime_format=""
         )
+        cdm_release_date_cast = normalization.Normalizer.generate_date_datetime_cast(
+            column_name="cdm_release_date",
+            column_type="DATE",
+            default_value=f"'{delivery_date}'",
+            date_format=date_format,
+            datetime_format=""
+        )
         cdm_version_concept_id = utils.get_cdm_version_concept_id(target_cdm_version)
         return f"""
             COPY (
                 SELECT * REPLACE (
                     {source_release_date_cast} AS source_release_date,
-                    CAST('{delivery_date}' AS DATE) AS cdm_release_date,
+                    {cdm_release_date_cast} AS cdm_release_date,
                     '{target_cdm_version}' AS cdm_version,
                     {cdm_version_concept_id} AS cdm_version_concept_id,
                     '{target_vocab_version}' AS vocabulary_version

--- a/core/omop_client.py
+++ b/core/omop_client.py
@@ -99,10 +99,11 @@ class OMOPClient:
         Populate cdm_source Parquet file with metadata if empty, non-existent, or contains multiple rows.
 
         Checks if site delivered cdm_source file and populates it with metadata if needed:
-        - If file exists with exactly one row: keep the site-delivered row but always
-          rewrite two columns: source_release_date (keeps site value if parseable, else
-          falls back to delivery_date) and cdm_release_date (unconditionally set to
-          delivery_date). Every other site-delivered column passes through unchanged.
+        - If file exists with exactly one row: keep the site-delivered descriptive columns but
+          overwrite the pipeline-controlled fields: source_release_date (keeps site value if
+          parseable, else delivery_date), cdm_release_date (=delivery_date), and
+          cdm_version / cdm_version_concept_id / vocabulary_version (=the target the data was
+          standardized to). Every other site-delivered column passes through unchanged.
         - If file exists with multiple rows: treat as if no rows were delivered and populate
         - If file exists but is empty: populate with metadata
         - If file doesn't exist: create and populate with metadata
@@ -147,9 +148,15 @@ class OMOPClient:
             populate_sql = OMOPClient.generate_populate_cdm_source_sql(cdm_source_data, cdm_source_uri)
             utils.execute_duckdb_sql(populate_sql, "Unable to populate cdm_source file")
         elif row_count == 1:
-            utils.logger.info("cdm_source file has 1 row, rewriting source_release_date (fallback to delivery_date if unparseable) and cdm_release_date (always delivery_date)")
-            rewrite_sql = OMOPClient.generate_rewrite_release_dates_sql(cdm_source_uri, date_format, delivery_date)
-            utils.execute_duckdb_sql(rewrite_sql, "Unable to rewrite release dates in cdm_source")
+            utils.logger.info("cdm_source file has 1 row; rewriting release dates and overwriting cdm/vocab versions to target")
+            rewrite_sql = OMOPClient.generate_rewrite_cdm_source_sql(
+                cdm_source_uri,
+                date_format,
+                delivery_date,
+                cdm_source_data["target_cdm_version"],
+                cdm_source_data["target_vocab_version"],
+            )
+            utils.execute_duckdb_sql(rewrite_sql, "Unable to rewrite cdm_source")
         else:  # row_count > 1
             utils.logger.warning(f"cdm_source file has {row_count} rows, treating as if no rows were delivered and re-populating")
             populate_sql = OMOPClient.generate_populate_cdm_source_sql(cdm_source_data, cdm_source_uri)
@@ -365,17 +372,22 @@ class OMOPClient:
         return cdm_source_statement
 
     @staticmethod
-    def generate_rewrite_release_dates_sql(cdm_source_uri: str, date_format: str, delivery_date: str) -> str:
+    def generate_rewrite_cdm_source_sql(
+        cdm_source_uri: str,
+        date_format: str,
+        delivery_date: str,
+        target_cdm_version: str,
+        target_vocab_version: str,
+    ) -> str:
         """
-        Generate SQL that overwrites the cdm_source parquet, replacing two columns:
+        Rewrite a site-delivered 1-row cdm_source in place, overwriting pipeline-controlled fields:
 
-        - source_release_date: COALESCE that keeps the site-delivered value if it
-          parses via date_format or direct cast, otherwise falls back to delivery_date.
-        - cdm_release_date: unconditionally set to delivery_date (the pipeline always
-          stamps this with the delivery date regardless of what the site provided).
+        - source_release_date: site value if parseable (date_format or direct cast), else delivery_date.
+        - cdm_release_date: always delivery_date.
+        - cdm_version / cdm_version_concept_id / vocabulary_version: the target the pipeline
+          standardized the data to (site's self-reported values are discarded).
 
-        Uses DuckDB's SELECT * REPLACE so every other site-delivered column passes
-        through unchanged.
+        SELECT * REPLACE passes every other (descriptive) site-delivered column through unchanged.
         """
         source_release_date_cast = normalization.Normalizer.generate_date_datetime_cast(
             column_name="source_release_date",
@@ -384,11 +396,15 @@ class OMOPClient:
             date_format=date_format,
             datetime_format=""
         )
+        cdm_version_concept_id = utils.get_cdm_version_concept_id(target_cdm_version)
         return f"""
             COPY (
                 SELECT * REPLACE (
                     {source_release_date_cast} AS source_release_date,
-                    CAST('{delivery_date}' AS DATE) AS cdm_release_date
+                    CAST('{delivery_date}' AS DATE) AS cdm_release_date,
+                    '{target_cdm_version}' AS cdm_version,
+                    {cdm_version_concept_id} AS cdm_version_concept_id,
+                    '{target_vocab_version}' AS vocabulary_version
                 )
                 FROM read_parquet('{cdm_source_uri}')
             ) TO '{cdm_source_uri}' {constants.DUCKDB_FORMAT_STRING}

--- a/core/utils.py
+++ b/core/utils.py
@@ -104,7 +104,6 @@ def _ensure_local_copy_parents(sql: str) -> None:
     for uri in re.findall(r"\bTO\s+'(file://[^']+)'", sql, flags=re.IGNORECASE):
         storage.ensure_parent_directory(uri)
 
-
 def execute_duckdb_sql(sql: str, error_msg: str, return_results: bool = False, load_encodings: bool = False):
     """
     Execute SQL statement using DuckDB with automatic connection management.

--- a/core/utils.py
+++ b/core/utils.py
@@ -515,9 +515,7 @@ def placeholder_to_post_processing_path(site: str, bucket: str, delivery_date: s
     Replaces placeholder strings in post-processing SQL with paths to the appropriate parquet files.
 
     Like placeholder_to_harmonized_file_path, but also covers additional converted_files
-    tables (care_site, location, provider, visit_detail, episode, cost,
-    payer_plan_period, metadata, cdm_source, fact_relationship, note_nlp) that are
-    not exposed to derived-table generation.
+    tables that are not exposed to derived-table generation.
 
     Routing rules:
       - Tables in VOCAB_HARMONIZED_TABLES: omop_etl/{table}/{table}.parquet
@@ -560,8 +558,6 @@ def placeholder_to_harmonized_file_path(site: str, bucket: str, delivery_date: s
     This intelligently determines the correct path based on whether the table underwent vocabulary harmonization:
     - Harmonized tables (in VOCAB_HARMONIZED_TABLES): {scheme}://{bucket}/{date}/artifacts/omop_etl/{table}/{table}.parquet
     - Non-harmonized tables (not in list): {scheme}://{bucket}/{date}/artifacts/converted_files/{table}.parquet
-
-    This is used for derived table generation after vocabulary harmonization is complete.
     """
     replacement_result = sql_script
 

--- a/tests/reference/sql/connect_data/participant_status_all_sites.sql
+++ b/tests/reference/sql/connect_data/participant_status_all_sites.sql
@@ -8,31 +8,51 @@ WITH status_map AS (
 	SELECT '219863910' AS concept_id, 'Cannot be Verified' AS concept_name UNION ALL
 	SELECT '104430631' AS concept_id, 'No' AS concept_name UNION ALL
 	SELECT '353358909' AS concept_id, 'Yes' AS concept_name
-), statuses AS (
+),
+completion_status_map AS (
+  SELECT '972455046' AS concept_id, 'Not Started' AS concept_name UNION ALL
+  SELECT '615768760' AS concept_id, 'Started' AS concept_name UNION ALL
+  SELECT '231311385' AS concept_id, 'Submitted' AS concept_name
+),
+statuses AS (
   SELECT DISTINCT
     Connect_ID,
+    -- Participant status fields
     d_821247024,
     d_747006172,
     d_773707518,
     d_831041022,
+    -- Module/survey completion status fields
+    d_949302066,
+    d_536735468,
+    d_976570371,
+    d_663265240,
+    --d_265193023,
+    --d_253883960,
+    --d_547363263,
+    d_459098666,
+    d_220186468,
+    d_956490759,
+    -- Timestamp fields
     d_659990606,
     d_664453818,
     d_269050420,
-    D_517311251,
-    D_832139544,
-    D_770257102,
+    d_517311251,
+    d_832139544,
+    d_770257102,
     d_264644252,
-    d_222161762,
-    d_764863765,
-    d_195145666,
+    --d_222161762,
+    --d_764863765,
+    --d_195145666,
     d_217640691,
     d_784810139,
     d_199471989
   FROM `test-project.test_dataset.participants`
-
+  
 ), cleaned_datapoints AS (
   SELECT DISTINCT
     Connect_ID,
+    -- Participant status fields
     CASE WHEN smap_vs.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_vs.concept_name END AS verified_status,
     d_821247024 AS verified_status_concept_id,
     CASE WHEN smap_cw.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_cw.concept_name END AS consent_withdrawn,
@@ -41,16 +61,38 @@ WITH status_map AS (
     d_773707518 AS hipaa_revoked_concept_id,
     CASE WHEN smap_dd.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_dd.concept_name END AS data_destruction_requested,
     d_831041022 AS data_destruction_requested_concept_id,
+    -- Module/survey completion status fields
+    COALESCE(smap_m1.concept_name, 'UNKNOWN') AS module1_status,
+    d_949302066 AS module1_status_concept_id,
+    COALESCE(smap_m2.concept_name, 'UNKNOWN') AS module2_status,
+    d_536735468 AS module2_status_concept_id,
+    COALESCE(smap_m3.concept_name, 'UNKNOWN') AS module3_status,
+    d_976570371 AS module3_status_concept_id,
+    COALESCE(smap_m4.concept_name, 'UNKNOWN') AS module4_status,
+    d_663265240 AS module4_status_concept_id,
+    --COALESCE(smap_bio.concept_name, 'UNKNOWN') AS bio_status,
+    --d_265193023 AS bio_status_concept_id,
+    --COALESCE(smap_clbio.concept_name, 'UNKNOWN') AS clinicalbio_status,
+    --d_253883960 AS clinicalbio_status_concept_id,
+    --COALESCE(smap_mw.concept_name, 'UNKNOWN') AS mouthwash_status,
+    --d_547363263 AS mouthwash_status_concept_id,
+    COALESCE(smap_mens.concept_name, 'UNKNOWN') AS menstrual_status,
+    d_459098666 AS menstrual_status_concept_id,
+    COALESCE(smap_covid.concept_name, 'UNKNOWN') AS covid19_status,
+    d_220186468 AS covid19_status_concept_id,
+    COALESCE(smap_exp2024.concept_name, 'UNKNOWN') AS experience2024_status,
+    d_956490759 AS experience2024_status_concept_id,
+    -- Timestamp fields
     d_659990606 AS consent_withdrawn_ts,
     d_664453818 AS hipaa_revoked_ts,
     d_269050420 AS data_destruction_ts,
-    D_517311251 AS module1_complete_ts,
-    D_832139544 AS module2_complete_ts,
-    D_770257102 AS module3_complete_ts,
+    d_517311251 AS module1_complete_ts,
+    d_832139544 AS module2_complete_ts,
+    d_770257102 AS module3_complete_ts,
     d_264644252 AS module4_complete_ts,
-    d_222161762 AS bio_complete_ts,
-    d_764863765 AS clinicalbio_complete_ts,
-    d_195145666 AS mouthwash_complete_ts,
+    --d_222161762 AS bio_complete_ts,
+    --d_764863765 AS clinicalbio_complete_ts,
+    --d_195145666 AS mouthwash_complete_ts,
     d_217640691 AS menstrual_complete_ts,
     d_784810139 AS covid19_complete_ts,
     d_199471989 AS experience2024_complete_ts
@@ -59,6 +101,16 @@ WITH status_map AS (
   LEFT JOIN status_map smap_cw ON s.d_747006172 = smap_cw.concept_id
   LEFT JOIN status_map smap_hr ON s.d_773707518 = smap_hr.concept_id
   LEFT JOIN status_map smap_dd ON s.d_831041022 = smap_dd.concept_id
+  LEFT JOIN completion_status_map smap_m1 ON s.d_949302066 = smap_m1.concept_id
+  LEFT JOIN completion_status_map smap_m2 ON s.d_536735468 = smap_m2.concept_id
+  LEFT JOIN completion_status_map smap_m3 ON s.d_976570371 = smap_m3.concept_id
+  LEFT JOIN completion_status_map smap_m4 ON s.d_663265240 = smap_m4.concept_id
+  --LEFT JOIN completion_status_map smap_bio ON s.d_265193023 = smap_bio.concept_id
+  --LEFT JOIN completion_status_map smap_clbio ON s.d_253883960 = smap_clbio.concept_id
+  --LEFT JOIN completion_status_map smap_mw ON s.d_547363263 = smap_mw.concept_id
+  LEFT JOIN completion_status_map smap_mens ON s.d_459098666 = smap_mens.concept_id
+  LEFT JOIN completion_status_map smap_covid ON s.d_220186468 = smap_covid.concept_id
+  LEFT JOIN completion_status_map smap_exp2024 ON s.d_956490759 = smap_exp2024.concept_id
   WHERE Connect_ID IS NOT NULL
 )
 SELECT * FROM cleaned_datapoints

--- a/tests/reference/sql/connect_data/participant_status_with_site_filter.sql
+++ b/tests/reference/sql/connect_data/participant_status_with_site_filter.sql
@@ -8,23 +8,42 @@ WITH status_map AS (
 	SELECT '219863910' AS concept_id, 'Cannot be Verified' AS concept_name UNION ALL
 	SELECT '104430631' AS concept_id, 'No' AS concept_name UNION ALL
 	SELECT '353358909' AS concept_id, 'Yes' AS concept_name
-), statuses AS (
+),
+completion_status_map AS (
+  SELECT '972455046' AS concept_id, 'Not Started' AS concept_name UNION ALL
+  SELECT '615768760' AS concept_id, 'Started' AS concept_name UNION ALL
+  SELECT '231311385' AS concept_id, 'Submitted' AS concept_name
+),
+statuses AS (
   SELECT DISTINCT
     Connect_ID,
+    -- Participant status fields
     d_821247024,
     d_747006172,
     d_773707518,
     d_831041022,
+    -- Module/survey completion status fields
+    d_949302066,
+    d_536735468,
+    d_976570371,
+    d_663265240,
+    --d_265193023,
+    --d_253883960,
+    --d_547363263,
+    d_459098666,
+    d_220186468,
+    d_956490759,
+    -- Timestamp fields
     d_659990606,
     d_664453818,
     d_269050420,
-    D_517311251,
-    D_832139544,
-    D_770257102,
+    d_517311251,
+    d_832139544,
+    d_770257102,
     d_264644252,
-    d_222161762,
-    d_764863765,
-    d_195145666,
+    --d_222161762,
+    --d_764863765,
+    --d_195145666,
     d_217640691,
     d_784810139,
     d_199471989
@@ -33,6 +52,7 @@ WITH status_map AS (
 ), cleaned_datapoints AS (
   SELECT DISTINCT
     Connect_ID,
+    -- Participant status fields
     CASE WHEN smap_vs.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_vs.concept_name END AS verified_status,
     d_821247024 AS verified_status_concept_id,
     CASE WHEN smap_cw.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_cw.concept_name END AS consent_withdrawn,
@@ -41,16 +61,38 @@ WITH status_map AS (
     d_773707518 AS hipaa_revoked_concept_id,
     CASE WHEN smap_dd.concept_name IS NULL THEN 'UNKNOWN' ELSE smap_dd.concept_name END AS data_destruction_requested,
     d_831041022 AS data_destruction_requested_concept_id,
+    -- Module/survey completion status fields
+    COALESCE(smap_m1.concept_name, 'UNKNOWN') AS module1_status,
+    d_949302066 AS module1_status_concept_id,
+    COALESCE(smap_m2.concept_name, 'UNKNOWN') AS module2_status,
+    d_536735468 AS module2_status_concept_id,
+    COALESCE(smap_m3.concept_name, 'UNKNOWN') AS module3_status,
+    d_976570371 AS module3_status_concept_id,
+    COALESCE(smap_m4.concept_name, 'UNKNOWN') AS module4_status,
+    d_663265240 AS module4_status_concept_id,
+    --COALESCE(smap_bio.concept_name, 'UNKNOWN') AS bio_status,
+    --d_265193023 AS bio_status_concept_id,
+    --COALESCE(smap_clbio.concept_name, 'UNKNOWN') AS clinicalbio_status,
+    --d_253883960 AS clinicalbio_status_concept_id,
+    --COALESCE(smap_mw.concept_name, 'UNKNOWN') AS mouthwash_status,
+    --d_547363263 AS mouthwash_status_concept_id,
+    COALESCE(smap_mens.concept_name, 'UNKNOWN') AS menstrual_status,
+    d_459098666 AS menstrual_status_concept_id,
+    COALESCE(smap_covid.concept_name, 'UNKNOWN') AS covid19_status,
+    d_220186468 AS covid19_status_concept_id,
+    COALESCE(smap_exp2024.concept_name, 'UNKNOWN') AS experience2024_status,
+    d_956490759 AS experience2024_status_concept_id,
+    -- Timestamp fields
     d_659990606 AS consent_withdrawn_ts,
     d_664453818 AS hipaa_revoked_ts,
     d_269050420 AS data_destruction_ts,
-    D_517311251 AS module1_complete_ts,
-    D_832139544 AS module2_complete_ts,
-    D_770257102 AS module3_complete_ts,
+    d_517311251 AS module1_complete_ts,
+    d_832139544 AS module2_complete_ts,
+    d_770257102 AS module3_complete_ts,
     d_264644252 AS module4_complete_ts,
-    d_222161762 AS bio_complete_ts,
-    d_764863765 AS clinicalbio_complete_ts,
-    d_195145666 AS mouthwash_complete_ts,
+    --d_222161762 AS bio_complete_ts,
+    --d_764863765 AS clinicalbio_complete_ts,
+    --d_195145666 AS mouthwash_complete_ts,
     d_217640691 AS menstrual_complete_ts,
     d_784810139 AS covid19_complete_ts,
     d_199471989 AS experience2024_complete_ts
@@ -59,6 +101,16 @@ WITH status_map AS (
   LEFT JOIN status_map smap_cw ON s.d_747006172 = smap_cw.concept_id
   LEFT JOIN status_map smap_hr ON s.d_773707518 = smap_hr.concept_id
   LEFT JOIN status_map smap_dd ON s.d_831041022 = smap_dd.concept_id
+  LEFT JOIN completion_status_map smap_m1 ON s.d_949302066 = smap_m1.concept_id
+  LEFT JOIN completion_status_map smap_m2 ON s.d_536735468 = smap_m2.concept_id
+  LEFT JOIN completion_status_map smap_m3 ON s.d_976570371 = smap_m3.concept_id
+  LEFT JOIN completion_status_map smap_m4 ON s.d_663265240 = smap_m4.concept_id
+  --LEFT JOIN completion_status_map smap_bio ON s.d_265193023 = smap_bio.concept_id
+  --LEFT JOIN completion_status_map smap_clbio ON s.d_253883960 = smap_clbio.concept_id
+  --LEFT JOIN completion_status_map smap_mw ON s.d_547363263 = smap_mw.concept_id
+  LEFT JOIN completion_status_map smap_mens ON s.d_459098666 = smap_mens.concept_id
+  LEFT JOIN completion_status_map smap_covid ON s.d_220186468 = smap_covid.concept_id
+  LEFT JOIN completion_status_map smap_exp2024 ON s.d_956490759 = smap_exp2024.concept_id
   WHERE Connect_ID IS NOT NULL
 )
 SELECT * FROM cleaned_datapoints

--- a/tests/reference/sql/merge/extract_chunk_all_scope.sql
+++ b/tests/reference/sql/merge/extract_chunk_all_scope.sql
@@ -1,0 +1,5 @@
+
+            COPY (
+                SELECT * FROM read_parquet('gs://siteA/2025-01-01/artifacts/converted_files/measurement.parquet')
+            ) TO 'gs://ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
+            

--- a/tests/reference/sql/merge/extract_chunk_id_scope.sql
+++ b/tests/reference/sql/merge/extract_chunk_id_scope.sql
@@ -1,8 +1,0 @@
-
-        COPY (
-            SELECT * FROM read_parquet('gs://siteA/2025-01-01/artifacts/converted_files/measurement.parquet')
-            WHERE person_id IN (
-                SELECT id FROM read_parquet('gs://ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/siteA__2025-01-01.parquet')
-            )
-        ) TO 'gs://ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
-        

--- a/tests/reference/sql/merge/extract_chunk_id_scope.sql
+++ b/tests/reference/sql/merge/extract_chunk_id_scope.sql
@@ -1,0 +1,8 @@
+
+        COPY (
+            SELECT * FROM read_parquet('gs://siteA/2025-01-01/artifacts/converted_files/measurement.parquet')
+            WHERE person_id IN (
+                SELECT id FROM read_parquet('gs://ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/siteA__2025-01-01.parquet')
+            )
+        ) TO 'gs://ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
+        

--- a/tests/reference/sql/merge/merge_delivery_row_count.sql
+++ b/tests/reference/sql/merge/merge_delivery_row_count.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) AS row_count
+FROM read_parquet('gs://ehr_merged/2026-06-24/artifacts/merge_chunks/*/*__siteA__2025-01-01.parquet', union_by_name=true)

--- a/tests/reference/sql/merge/reconcile_chunks_union_by_name.sql
+++ b/tests/reference/sql/merge/reconcile_chunks_union_by_name.sql
@@ -1,0 +1,5 @@
+
+        COPY (
+            SELECT * FROM read_parquet('gs://ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/*.parquet', union_by_name=true)
+        ) TO 'gs://ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)
+        

--- a/tests/reference/sql/omop_client/generate_get_delivery_cdm_version_sql_standard.sql
+++ b/tests/reference/sql/omop_client/generate_get_delivery_cdm_version_sql_standard.sql
@@ -1,0 +1,5 @@
+
+            SELECT cdm_version, vocabulary_version
+            FROM read_parquet('gs://siteA/2025-01-01/artifacts/converted_files/cdm_source.parquet')
+            LIMIT 1
+        

--- a/tests/reference/sql/omop_client/generate_rewrite_cdm_source_sql_standard.sql
+++ b/tests/reference/sql/omop_client/generate_rewrite_cdm_source_sql_standard.sql
@@ -6,7 +6,11 @@
                         TRY_CAST(source_release_date AS DATE),
                         CAST('2025-01-15' AS DATE)
                     ) AS source_release_date,
-                    CAST('2025-01-15' AS DATE) AS cdm_release_date,
+                    COALESCE(
+                        TRY_CAST(TRY_STRPTIME(CAST(cdm_release_date AS VARCHAR), '%Y-%m-%d') AS DATE),
+                        TRY_CAST(cdm_release_date AS DATE),
+                        CAST('2025-01-15' AS DATE)
+                    ) AS cdm_release_date,
                     '5.4' AS cdm_version,
                     756265 AS cdm_version_concept_id,
                     'v5.0 27-AUG-25' AS vocabulary_version

--- a/tests/reference/sql/omop_client/generate_rewrite_cdm_source_sql_standard.sql
+++ b/tests/reference/sql/omop_client/generate_rewrite_cdm_source_sql_standard.sql
@@ -6,7 +6,10 @@
                         TRY_CAST(source_release_date AS DATE),
                         CAST('2025-01-15' AS DATE)
                     ) AS source_release_date,
-                    CAST('2025-01-15' AS DATE) AS cdm_release_date
+                    CAST('2025-01-15' AS DATE) AS cdm_release_date,
+                    '5.4' AS cdm_version,
+                    756265 AS cdm_version_concept_id,
+                    'v5.0 27-AUG-25' AS vocabulary_version
                 )
                 FROM read_parquet('gs://test-bucket/2025-01-15/artifacts/converted_files/cdm_source.parquet')
             ) TO 'gs://test-bucket/2025-01-15/artifacts/converted_files/cdm_source.parquet' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1268,3 +1268,151 @@ class TestPipelineLogEndpoint:
 
         assert response.status_code == 500
         assert b"Unable to save logging information" in response.data
+
+
+class TestGetLatestCompletedDeliveryEndpoint:
+    """Tests for /get_latest_completed_delivery endpoint."""
+
+    @patch('core.endpoints.pipeline_log.get_latest_completed_delivery')
+    def test_success(self, mock_get, client):
+        mock_get.return_value = '2025-03-01'
+
+        response = client.post('/get_latest_completed_delivery', json={'site': 'siteA'})
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data['delivery_date'] == '2025-03-01'
+        mock_get.assert_called_once_with('siteA')
+
+    @patch('core.endpoints.pipeline_log.get_latest_completed_delivery')
+    def test_no_completed_delivery_returns_null(self, mock_get, client):
+        mock_get.return_value = None
+
+        response = client.post('/get_latest_completed_delivery', json={'site': 'siteA'})
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data['delivery_date'] is None
+
+    def test_missing_parameter(self, client):
+        response = client.post('/get_latest_completed_delivery', json={})
+        assert_missing_fields(response, 'site')
+
+    @patch('core.endpoints.pipeline_log.get_latest_completed_delivery')
+    def test_exception(self, mock_get, client):
+        mock_get.side_effect = Exception("BigQuery error")
+
+        response = client.post('/get_latest_completed_delivery', json={'site': 'siteA'})
+
+        assert response.status_code == 500
+        assert b"Unable to get latest completed delivery" in response.data
+
+
+class TestGetDeliveryCdmVersionEndpoint:
+    """Tests for /get_delivery_cdm_version endpoint."""
+
+    @patch('core.endpoints.omop_client.OMOPClient.get_delivery_cdm_version')
+    def test_success(self, mock_get, client):
+        mock_get.return_value = {'cdm_version': '5.4', 'vocabulary_version': 'v5.0 27-AUG-25'}
+
+        response = client.post('/get_delivery_cdm_version', json={
+            'bucket': 'siteA',
+            'delivery_date': '2025-01-01'
+        })
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data['cdm_version'] == '5.4'
+        assert data['vocabulary_version'] == 'v5.0 27-AUG-25'
+        mock_get.assert_called_once_with('siteA', '2025-01-01')
+
+    def test_missing_parameters(self, client):
+        response = client.post('/get_delivery_cdm_version', json={'bucket': 'siteA'})
+        assert_missing_fields(response, 'delivery_date')
+
+    @patch('core.endpoints.omop_client.OMOPClient.get_delivery_cdm_version')
+    def test_exception(self, mock_get, client):
+        mock_get.side_effect = Exception("read failed")
+
+        response = client.post('/get_delivery_cdm_version', json={
+            'bucket': 'siteA',
+            'delivery_date': '2025-01-01'
+        })
+
+        assert response.status_code == 500
+        assert b"Unable to read cdm_version" in response.data
+
+
+class TestExtractParticipantChunkEndpoint:
+    """Tests for /extract_participant_chunk endpoint."""
+
+    @patch('core.endpoints.merge.MergeProcessor.extract_chunk')
+    def test_success_all_scope(self, mock_extract, client):
+        response = client.post('/extract_participant_chunk', json={
+            'source_uri': 'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
+            'chunk_uri': 'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
+            'participant_scope': 'ALL'
+        })
+
+        assert response.status_code == 200
+        assert b"Extracted participant chunk" in response.data
+        # Optional person_id_column defaults to the constant.
+        mock_extract.assert_called_once_with(
+            'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
+            'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
+            'ALL',
+            constants.DEFAULT_PERSON_ID_COLUMN
+        )
+
+    def test_missing_parameters(self, client):
+        response = client.post('/extract_participant_chunk', json={
+            'source_uri': 'siteA/2025-01-01/artifacts/converted_files/measurement.parquet'
+        })
+        assert_missing_fields(response, 'chunk_uri', 'participant_scope')
+
+    @patch('core.endpoints.merge.MergeProcessor.extract_chunk')
+    def test_exception(self, mock_extract, client):
+        mock_extract.side_effect = Exception("extract failed")
+
+        response = client.post('/extract_participant_chunk', json={
+            'source_uri': 'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
+            'chunk_uri': 'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
+            'participant_scope': 'ALL'
+        })
+
+        assert response.status_code == 500
+        assert b"Unable to extract participant chunk" in response.data
+
+
+class TestReconcileChunksEndpoint:
+    """Tests for /reconcile_chunks endpoint."""
+
+    @patch('core.endpoints.merge.MergeProcessor.reconcile_chunks')
+    def test_success(self, mock_reconcile, client):
+        response = client.post('/reconcile_chunks', json={
+            'chunk_glob': 'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/*.parquet',
+            'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet'
+        })
+
+        assert response.status_code == 200
+        assert b"Reconciled merge chunks" in response.data
+        mock_reconcile.assert_called_once_with(
+            'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/*.parquet',
+            'ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet'
+        )
+
+    def test_missing_parameters(self, client):
+        response = client.post('/reconcile_chunks', json={})
+        assert_missing_fields(response, 'chunk_glob', 'output_uri')
+
+    @patch('core.endpoints.merge.MergeProcessor.reconcile_chunks')
+    def test_exception(self, mock_reconcile, client):
+        mock_reconcile.side_effect = Exception("no chunks matched glob")
+
+        response = client.post('/reconcile_chunks', json={
+            'chunk_glob': 'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/*.parquet',
+            'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet'
+        })
+
+        assert response.status_code == 500
+        assert b"Unable to reconcile merge chunks" in response.data

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1356,12 +1356,11 @@ class TestExtractParticipantChunkEndpoint:
 
         assert response.status_code == 200
         assert b"Extracted participant chunk" in response.data
-        # Optional person_id_column defaults to the constant; site_display_name is None (no stamp).
+        # site_display_name is None (no stamp) when not supplied.
         mock_extract.assert_called_once_with(
             'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
             'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
             'ALL',
-            constants.DEFAULT_PERSON_ID_COLUMN,
             None
         )
 
@@ -1380,7 +1379,6 @@ class TestExtractParticipantChunkEndpoint:
             'siteA/2025-01-01/artifacts/converted_files/person.parquet',
             'ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet',
             'ALL',
-            constants.DEFAULT_PERSON_ID_COLUMN,
             'Site A'
         )
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1347,11 +1347,10 @@ class TestExtractParticipantChunkEndpoint:
     """Tests for /extract_participant_chunk endpoint."""
 
     @patch('core.endpoints.merge.MergeProcessor.extract_chunk')
-    def test_success_all_scope(self, mock_extract, client):
+    def test_success(self, mock_extract, client):
         response = client.post('/extract_participant_chunk', json={
             'source_uri': 'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
             'chunk_uri': 'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
-            'participant_scope': 'ALL'
         })
 
         assert response.status_code == 200
@@ -1360,7 +1359,6 @@ class TestExtractParticipantChunkEndpoint:
         mock_extract.assert_called_once_with(
             'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
             'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
-            'ALL',
             None
         )
 
@@ -1369,7 +1367,6 @@ class TestExtractParticipantChunkEndpoint:
         response = client.post('/extract_participant_chunk', json={
             'source_uri': 'siteA/2025-01-01/artifacts/converted_files/person.parquet',
             'chunk_uri': 'ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet',
-            'participant_scope': 'ALL',
             'site_display_name': 'Site A',
         })
 
@@ -1378,7 +1375,6 @@ class TestExtractParticipantChunkEndpoint:
         mock_extract.assert_called_once_with(
             'siteA/2025-01-01/artifacts/converted_files/person.parquet',
             'ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet',
-            'ALL',
             'Site A'
         )
 
@@ -1386,7 +1382,7 @@ class TestExtractParticipantChunkEndpoint:
         response = client.post('/extract_participant_chunk', json={
             'source_uri': 'siteA/2025-01-01/artifacts/converted_files/measurement.parquet'
         })
-        assert_missing_fields(response, 'chunk_uri', 'participant_scope')
+        assert_missing_fields(response, 'chunk_uri')
 
     @patch('core.endpoints.merge.MergeProcessor.extract_chunk')
     def test_exception(self, mock_extract, client):
@@ -1395,7 +1391,6 @@ class TestExtractParticipantChunkEndpoint:
         response = client.post('/extract_participant_chunk', json={
             'source_uri': 'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
             'chunk_uri': 'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
-            'participant_scope': 'ALL'
         })
 
         assert response.status_code == 500

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1477,6 +1477,53 @@ class TestBuildCareSiteEndpoint:
         assert b"Unable to build care_site table" in response.data
 
 
+class TestBuildMergeCdmSourceEndpoint:
+    """Tests for /build_merge_cdm_source endpoint."""
+
+    PAYLOAD = {
+        'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/cdm_source.parquet',
+        'source_cdm_source_uris': [
+            'siteA/2025-01-01/artifacts/converted_files/cdm_source.parquet',
+            'siteB/2025-02-01/artifacts/converted_files/cdm_source.parquet',
+        ],
+        'site_count': 2,
+        'cdm_version': '5.4',
+        'vocabulary_version': 'v5.0 27-AUG-25',
+        'cdm_release_date': '2026-06-24',
+    }
+
+    @patch('core.endpoints.merge.MergeProcessor.build_cdm_source')
+    def test_success(self, mock_build, client):
+        response = client.post('/build_merge_cdm_source', json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        assert b"Built cdm_source" in response.data
+        mock_build.assert_called_once_with(
+            self.PAYLOAD['output_uri'],
+            self.PAYLOAD['source_cdm_source_uris'],
+            2,
+            '5.4',
+            'v5.0 27-AUG-25',
+            '2026-06-24',
+        )
+
+    def test_missing_parameters(self, client):
+        response = client.post('/build_merge_cdm_source', json={
+            'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/cdm_source.parquet'
+        })
+        assert_missing_fields(
+            response, 'source_cdm_source_uris', 'site_count', 'cdm_version', 'vocabulary_version', 'cdm_release_date'
+        )
+
+    @patch('core.endpoints.merge.MergeProcessor.build_cdm_source')
+    def test_exception(self, mock_build, client):
+        mock_build.side_effect = Exception("build failed")
+        response = client.post('/build_merge_cdm_source', json=self.PAYLOAD)
+
+        assert response.status_code == 500
+        assert b"Unable to build cdm_source" in response.data
+
+
 class TestGenerateMergeReportEndpoint:
     """Tests for /generate_merge_report endpoint."""
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1356,12 +1356,32 @@ class TestExtractParticipantChunkEndpoint:
 
         assert response.status_code == 200
         assert b"Extracted participant chunk" in response.data
-        # Optional person_id_column defaults to the constant.
+        # Optional person_id_column defaults to the constant; site_display_name is None (no stamp).
         mock_extract.assert_called_once_with(
             'siteA/2025-01-01/artifacts/converted_files/measurement.parquet',
             'ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet',
             'ALL',
-            constants.DEFAULT_PERSON_ID_COLUMN
+            constants.DEFAULT_PERSON_ID_COLUMN,
+            None
+        )
+
+    @patch('core.endpoints.merge.MergeProcessor.extract_chunk')
+    def test_success_with_site_display_name(self, mock_extract, client):
+        response = client.post('/extract_participant_chunk', json={
+            'source_uri': 'siteA/2025-01-01/artifacts/converted_files/person.parquet',
+            'chunk_uri': 'ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet',
+            'participant_scope': 'ALL',
+            'site_display_name': 'Site A',
+        })
+
+        assert response.status_code == 200
+        # site_display_name is forwarded so person's care_site_id gets stamped.
+        mock_extract.assert_called_once_with(
+            'siteA/2025-01-01/artifacts/converted_files/person.parquet',
+            'ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet',
+            'ALL',
+            constants.DEFAULT_PERSON_ID_COLUMN,
+            'Site A'
         )
 
     def test_missing_parameters(self, client):
@@ -1416,6 +1436,45 @@ class TestReconcileChunksEndpoint:
 
         assert response.status_code == 500
         assert b"Unable to reconcile merge chunks" in response.data
+
+
+class TestBuildCareSiteEndpoint:
+    """Tests for /build_care_site endpoint."""
+
+    @patch('core.endpoints.merge.MergeProcessor.build_care_site')
+    def test_success(self, mock_build, client):
+        response = client.post('/build_care_site', json={
+            'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/care_site.parquet',
+            'site_display_names': ['Site A', 'Site B'],
+            'cdm_version': '5.4',
+        })
+
+        assert response.status_code == 200
+        assert b"Built care_site table" in response.data
+        mock_build.assert_called_once_with(
+            'ehr_merged/2026-06-24/artifacts/converted_files/care_site.parquet',
+            ['Site A', 'Site B'],
+            '5.4'
+        )
+
+    def test_missing_parameters(self, client):
+        response = client.post('/build_care_site', json={
+            'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/care_site.parquet'
+        })
+        assert_missing_fields(response, 'site_display_names', 'cdm_version')
+
+    @patch('core.endpoints.merge.MergeProcessor.build_care_site')
+    def test_exception(self, mock_build, client):
+        mock_build.side_effect = Exception("build failed")
+
+        response = client.post('/build_care_site', json={
+            'output_uri': 'ehr_merged/2026-06-24/artifacts/converted_files/care_site.parquet',
+            'site_display_names': ['Site A'],
+            'cdm_version': '5.4',
+        })
+
+        assert response.status_code == 500
+        assert b"Unable to build care_site table" in response.data
 
 
 class TestGenerateMergeReportEndpoint:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1416,3 +1416,45 @@ class TestReconcileChunksEndpoint:
 
         assert response.status_code == 500
         assert b"Unable to reconcile merge chunks" in response.data
+
+
+class TestGenerateMergeReportEndpoint:
+    """Tests for /generate_merge_report endpoint."""
+
+    @patch('core.endpoints.merge_reporting.MergeReporter.generate_merge_report')
+    def test_success(self, mock_report, client):
+        deliveries = [
+            {'site': 'siteA', 'delivery_date': '2025-01-01'},
+            {'site': 'siteB', 'delivery_date': '2025-02-01'},
+        ]
+        response = client.post('/generate_merge_report', json={
+            'merge_bucket': 'ehr_merged',
+            'run_date': '2026-06-24',
+            'site': 'merged_ehr',
+            'deliveries': deliveries,
+        })
+
+        assert response.status_code == 200
+        assert b"Generated merge report" in response.data
+        mock_report.assert_called_once_with('ehr_merged', '2026-06-24', 'merged_ehr', deliveries)
+
+    def test_missing_parameters(self, client):
+        response = client.post('/generate_merge_report', json={
+            'merge_bucket': 'ehr_merged',
+            'run_date': '2026-06-24',
+        })
+        assert_missing_fields(response, 'site', 'deliveries')
+
+    @patch('core.endpoints.merge_reporting.MergeReporter.generate_merge_report')
+    def test_exception(self, mock_report, client):
+        mock_report.side_effect = Exception("count failed")
+
+        response = client.post('/generate_merge_report', json={
+            'merge_bucket': 'ehr_merged',
+            'run_date': '2026-06-24',
+            'site': 'merged_ehr',
+            'deliveries': [{'site': 'siteA', 'delivery_date': '2025-01-01'}],
+        })
+
+        assert response.status_code == 500
+        assert b"Unable to generate merge report" in response.data

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -122,6 +122,48 @@ def test_extract_id_scope_subsets_participants(local_backend):
     assert kept == [101, 103]
 
 
+def test_extract_stamps_person_care_site_id(local_backend):
+    root = local_backend
+
+    # Source person rows carry an unrelated care_site_id that must be overwritten.
+    src = str(root / "siteA/2025-01-01/artifacts/converted_files/person.parquet")
+    _write_parquet(
+        src,
+        "SELECT * FROM (VALUES (101, 999),(102, 999)) AS t(person_id, care_site_id)",
+    )
+    chunk = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/person/person__siteA__2025-01-01.parquet")
+
+    merge.MergeProcessor.extract_chunk(
+        src, chunk, constants.PARTICIPANT_SCOPE_ALL, site_display_name="Site A"
+    )
+
+    expected_id = merge.MergeProcessor.hash_care_site_id("Site A")
+    chunk_uri = shared_storage.get_uri(chunk)
+    ids = _query(f"SELECT DISTINCT care_site_id FROM read_parquet('{chunk_uri}')")
+    assert ids == [(expected_id,)]
+
+
+def test_build_care_site_writes_typed_row_per_site(local_backend):
+    root = local_backend
+    output = str(root / "ehr_merged/2026-06-24/artifacts/converted_files/care_site.parquet")
+
+    merge.MergeProcessor.build_care_site(output, ["Site A", "Site B"], "5.4")
+
+    output_uri = shared_storage.get_uri(output)
+    rows = _query(
+        f"SELECT care_site_id, care_site_name FROM read_parquet('{output_uri}') ORDER BY care_site_name"
+    )
+    assert rows == [
+        (merge.MergeProcessor.hash_care_site_id("Site A"), "Site A"),
+        (merge.MergeProcessor.hash_care_site_id("Site B"), "Site B"),
+    ]
+
+    # Types come from the OMOP care_site schema, so the parquet loads to BQ cleanly.
+    types = {name: col_type for name, col_type, *_ in _query(f"DESCRIBE SELECT * FROM read_parquet('{output_uri}')")}
+    assert types["care_site_id"] == "BIGINT"
+    assert types["care_site_name"] == "VARCHAR"
+
+
 def test_generate_merge_report_writes_provenance_csv(local_backend):
     root = local_backend
     merge_bucket = str(root / "ehr_merged")

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -164,6 +164,41 @@ def test_build_care_site_writes_typed_row_per_site(local_backend):
     assert types["care_site_name"] == "VARCHAR"
 
 
+def test_build_cdm_source_writes_one_row_with_latest_release_date(local_backend):
+    root = local_backend
+
+    # Two sites' cdm_source files with different source_release_date values.
+    src_a = str(root / "siteA/2025-01-01/artifacts/converted_files/cdm_source.parquet")
+    _write_parquet(src_a, "SELECT CAST('2024-06-01' AS DATE) AS source_release_date")
+    src_b = str(root / "siteB/2025-02-01/artifacts/converted_files/cdm_source.parquet")
+    _write_parquet(src_b, "SELECT CAST('2025-03-15' AS DATE) AS source_release_date")
+
+    output = str(root / "ehr_merged/2026-06-24/artifacts/converted_files/cdm_source.parquet")
+    merge.MergeProcessor.build_cdm_source(
+        output_uri=output,
+        source_cdm_source_uris=[src_a, src_b],
+        site_count=2,
+        cdm_version="5.4",
+        vocabulary_version="v5.0 27-AUG-25",
+        cdm_release_date="2026-06-24",
+    )
+
+    output_uri = shared_storage.get_uri(output)
+    rows = _query(
+        "SELECT cdm_source_name, source_description, source_release_date, cdm_release_date, "
+        f"cdm_version, cdm_version_concept_id, vocabulary_version FROM read_parquet('{output_uri}')"
+    )
+    assert len(rows) == 1
+    (name, desc, source_release, cdm_release, cdm_ver, concept_id, vocab) = rows[0]
+    assert name == "Connect for Cancer Prevention EHR Data"
+    assert "from 2 sites" in desc
+    assert str(source_release) == "2025-03-15"  # latest across the two sites
+    assert str(cdm_release) == "2026-06-24"
+    assert cdm_ver == "5.4"
+    assert concept_id == 756265
+    assert vocab == "v5.0 27-AUG-25"
+
+
 def test_generate_merge_report_writes_provenance_csv(local_backend):
     root = local_backend
     merge_bucket = str(root / "ehr_merged")

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -16,6 +16,7 @@ import pytest
 
 import core.constants as constants
 import core.merge as merge
+import core.merge_reporting as merge_reporting
 import core.utils as utils
 from core.storage_backend import storage as shared_storage
 
@@ -119,3 +120,54 @@ def test_extract_id_scope_subsets_participants(local_backend):
         for r in _query(f"SELECT person_id FROM read_parquet('{chunk_uri}') ORDER BY person_id")
     ]
     assert kept == [101, 103]
+
+
+def test_generate_merge_report_writes_provenance_csv(local_backend):
+    root = local_backend
+    merge_bucket = str(root / "ehr_merged")
+    run_date = "2026-06-24"
+    chunks = f"{merge_bucket}/{run_date}/artifacts/merge_chunks"
+
+    # siteA delivery: measurement (2 rows) + person (1 row) = 3 rows into the merge.
+    _write_parquet(
+        f"{chunks}/measurement/measurement__siteA__2025-01-01.parquet",
+        "SELECT * FROM (VALUES (1,101),(2,102)) AS t(measurement_id, person_id)",
+    )
+    _write_parquet(
+        f"{chunks}/person/person__siteA__2025-01-01.parquet",
+        "SELECT * FROM (VALUES (101)) AS t(person_id)",
+    )
+    # siteB delivery: measurement (3 rows) = 3 rows into the merge.
+    _write_parquet(
+        f"{chunks}/measurement/measurement__siteB__2025-02-01.parquet",
+        "SELECT * FROM (VALUES (10,201),(11,202),(12,203)) AS t(measurement_id, person_id)",
+    )
+
+    deliveries = [
+        {"site": "siteA", "delivery_date": "2025-01-01"},
+        {"site": "siteB", "delivery_date": "2025-02-01"},
+    ]
+    merge_reporting.MergeReporter.generate_merge_report(
+        merge_bucket=merge_bucket, run_date=run_date, site="merged_ehr", deliveries=deliveries
+    )
+
+    csv_uri = shared_storage.get_uri(
+        f"{merge_bucket}/{run_date}/artifacts/delivery_report/delivery_report_merged_ehr_{run_date}.csv"
+    )
+    report = _query(f"SELECT name, value_as_string, value_as_number FROM read_csv('{csv_uri}', header=true)")
+
+    # Which sites were included.
+    included_sites = {value_as_string for name, value_as_string, _ in report if name == "Merge source site"}
+    assert included_sites == {"siteA", "siteB"}
+
+    # Which deliveries were included + rows each contributed.
+    delivery_row_counts = {
+        value_as_string: int(value_as_number)
+        for name, value_as_string, value_as_number in report
+        if name == "Merge source delivery row count"
+    }
+    assert delivery_row_counts == {"siteA__2025-01-01": 3, "siteB__2025-02-01": 3}
+
+    # Total rows across the whole merge (sum of the per-delivery counts).
+    total = [int(value_as_number) for name, _, value_as_number in report if name == "Merge total row count"]
+    assert total == [6]

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -1,0 +1,117 @@
+"""
+End-to-end tests for the merge extract + reconcile flow using real DuckDB and temp parquet.
+
+Two tiny per-"site" tables are extracted (scope=ALL) into provenance-named chunk files,
+then reconciled into a single merged table. Asserts union row counts, column union
+(union_by_name), and provenance file naming. A second test exercises the participant-id
+subset (v2) extract path.
+
+The shared storage backend is switched to 'local' so MergeProcessor reads/writes real
+files via the file:// scheme; DuckDB's temp directory is redirected to a temp path.
+"""
+
+import os
+
+import duckdb
+import pytest
+
+import core.constants as constants
+import core.merge as merge
+from core.storage_backend import storage as shared_storage
+
+
+def _write_parquet(con, path: str, select_sql: str) -> None:
+    """Write a parquet file at a plain local path (creating parent dirs)."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    con.execute(f"COPY ({select_sql}) TO '{path}' (FORMAT parquet)")
+
+
+@pytest.fixture
+def local_backend(tmp_path, monkeypatch):
+    """Point the shared storage backend and DuckDB temp dir at a local temp tree."""
+    monkeypatch.setattr(shared_storage, 'backend', constants.LOCAL_BACKEND)
+    monkeypatch.setattr(shared_storage, 'scheme', constants.BACKENDS[constants.LOCAL_BACKEND])
+    monkeypatch.setattr(constants, 'STORAGE_BACKEND', constants.LOCAL_BACKEND)
+
+    duckdb_tmp = tmp_path / "duckdb_tmp"
+    duckdb_tmp.mkdir()
+    monkeypatch.setenv('DUCKDB_TEMP_DIR', f"{duckdb_tmp}/")
+
+    return tmp_path
+
+
+def test_extract_all_then_reconcile_unions_rows_and_columns(local_backend):
+    root = local_backend
+    con = duckdb.connect()
+
+    # siteA: 2 rows, 3 columns
+    site_a_src = str(root / "siteA/2025-01-01/artifacts/converted_files/measurement.parquet")
+    _write_parquet(
+        con,
+        site_a_src,
+        "SELECT * FROM (VALUES (1,'101','5.0'),(2,'102','6.0')) AS t(measurement_id, person_id, value)",
+    )
+    # siteB: 3 rows, with an EXTRA column to exercise union_by_name schema alignment
+    site_b_src = str(root / "siteB/2025-02-01/artifacts/converted_files/measurement.parquet")
+    _write_parquet(
+        con,
+        site_b_src,
+        "SELECT * FROM (VALUES (10,'201','7.0','x'),(11,'202','8.0','y'),(12,'203','9.0','z')) "
+        "AS t(measurement_id, person_id, value, extra_col)",
+    )
+
+    chunk_dir = root / "ehr_merged/2026-06-24/artifacts/merge_chunks/measurement"
+    chunk_a = str(chunk_dir / "measurement__siteA__2025-01-01.parquet")
+    chunk_b = str(chunk_dir / "measurement__siteB__2025-02-01.parquet")
+    output = str(root / "ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet")
+
+    merge.MergeProcessor.extract_chunk(site_a_src, chunk_a, constants.PARTICIPANT_SCOPE_ALL)
+    merge.MergeProcessor.extract_chunk(site_b_src, chunk_b, constants.PARTICIPANT_SCOPE_ALL)
+
+    # Provenance-named chunk files land in the shared per-table staging folder.
+    assert os.path.exists(chunk_a)
+    assert os.path.exists(chunk_b)
+
+    merge.MergeProcessor.reconcile_chunks(str(chunk_dir / "*.parquet"), output)
+    assert os.path.exists(output)
+
+    verify = duckdb.connect()
+    row_count = verify.execute(f"SELECT count(*) FROM read_parquet('{output}')").fetchone()[0]
+    assert row_count == 5  # 2 (siteA) + 3 (siteB)
+
+    columns = {r[0] for r in verify.execute(f"DESCRIBE SELECT * FROM read_parquet('{output}')").fetchall()}
+    assert {"measurement_id", "person_id", "value", "extra_col"} <= columns
+
+    # siteA rows (no extra_col) are NULL-filled for the unioned column.
+    null_extra = verify.execute(
+        f"SELECT count(*) FROM read_parquet('{output}') WHERE extra_col IS NULL"
+    ).fetchone()[0]
+    assert null_extra == 2
+
+
+def test_extract_id_scope_subsets_participants(local_backend):
+    root = local_backend
+    con = duckdb.connect()
+
+    src = str(root / "siteA/2025-01-01/artifacts/converted_files/measurement.parquet")
+    _write_parquet(
+        con,
+        src,
+        "SELECT * FROM (VALUES (1,'101'),(2,'102'),(3,'103')) AS t(measurement_id, person_id)",
+    )
+    # Keep only participants 101 and 103.
+    ids_uri = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/keep.parquet")
+    _write_parquet(con, ids_uri, "SELECT * FROM (VALUES (101),(103)) AS t(id)")
+
+    chunk = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet")
+
+    merge.MergeProcessor.extract_chunk(src, chunk, ids_uri)
+
+    verify = duckdb.connect()
+    kept = [
+        r[0]
+        for r in verify.execute(
+            f"SELECT person_id FROM read_parquet('{chunk}') ORDER BY person_id"
+        ).fetchall()
+    ]
+    assert kept == ['101', '103']

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -99,9 +99,9 @@ def test_extract_id_scope_subsets_participants(local_backend):
         src,
         "SELECT * FROM (VALUES (1,'101'),(2,'102'),(3,'103')) AS t(measurement_id, person_id)",
     )
-    # Keep only participants 101 and 103.
+    # Keep only participants 101 and 103. The id column matches person_id's type (VARCHAR).
     ids_uri = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/keep.parquet")
-    _write_parquet(con, ids_uri, "SELECT * FROM (VALUES (101),(103)) AS t(id)")
+    _write_parquet(con, ids_uri, "SELECT * FROM (VALUES ('101'),('103')) AS t(id)")
 
     chunk = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet")
 

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -76,8 +76,8 @@ def test_extract_all_then_reconcile_unions_rows_and_columns(local_backend):
     chunk_b = str(chunk_dir / "measurement__siteB__2025-02-01.parquet")
     output = str(root / "ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet")
 
-    merge.MergeProcessor.extract_chunk(site_a_src, chunk_a, constants.PARTICIPANT_SCOPE_ALL)
-    merge.MergeProcessor.extract_chunk(site_b_src, chunk_b, constants.PARTICIPANT_SCOPE_ALL)
+    merge.MergeProcessor.extract_chunk(site_a_src, chunk_a)
+    merge.MergeProcessor.extract_chunk(site_b_src, chunk_b)
 
     # Provenance-named chunk files land in the shared per-table staging folder.
     assert shared_storage.file_exists(chunk_a)
@@ -98,30 +98,6 @@ def test_extract_all_then_reconcile_unions_rows_and_columns(local_backend):
     assert null_extra == 2
 
 
-def test_extract_id_scope_subsets_participants(local_backend):
-    root = local_backend
-
-    src = str(root / "siteA/2025-01-01/artifacts/converted_files/measurement.parquet")
-    _write_parquet(
-        src,
-        "SELECT * FROM (VALUES (1,101),(2,102),(3,103)) AS t(measurement_id, person_id)",
-    )
-    # Keep only participants 101 and 103. The id column is numeric, matching person_id.
-    ids_uri = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/keep.parquet")
-    _write_parquet(ids_uri, "SELECT * FROM (VALUES (101),(103)) AS t(id)")
-
-    chunk = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet")
-
-    merge.MergeProcessor.extract_chunk(src, chunk, ids_uri)
-
-    chunk_uri = shared_storage.get_uri(chunk)
-    kept = [
-        r[0]
-        for r in _query(f"SELECT person_id FROM read_parquet('{chunk_uri}') ORDER BY person_id")
-    ]
-    assert kept == [101, 103]
-
-
 def test_extract_stamps_person_care_site_id(local_backend):
     root = local_backend
 
@@ -133,9 +109,7 @@ def test_extract_stamps_person_care_site_id(local_backend):
     )
     chunk = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/person/person__siteA__2025-01-01.parquet")
 
-    merge.MergeProcessor.extract_chunk(
-        src, chunk, constants.PARTICIPANT_SCOPE_ALL, site_display_name="Site A"
-    )
+    merge.MergeProcessor.extract_chunk(src, chunk, site_display_name="Site A")
 
     expected_id = merge.MergeProcessor.hash_care_site_id("Site A")
     chunk_uri = shared_storage.get_uri(chunk)

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -190,7 +190,7 @@ def test_build_cdm_source_writes_one_row_with_latest_release_date(local_backend)
     )
     assert len(rows) == 1
     (name, desc, source_release, cdm_release, cdm_ver, concept_id, vocab) = rows[0]
-    assert name == "Connect for Cancer Prevention EHR Data"
+    assert name == constants.MERGE_CDM_SOURCE_NAME
     assert "from 2 sites" in desc
     assert str(source_release) == "2025-03-15"  # latest across the two sites
     assert str(cdm_release) == "2026-06-24"

--- a/tests/test_extract_reconcile_e2e.py
+++ b/tests/test_extract_reconcile_e2e.py
@@ -6,24 +6,18 @@ then reconciled into a single merged table. Asserts union row counts, column uni
 (union_by_name), and provenance file naming. A second test exercises the participant-id
 subset (v2) extract path.
 
-The shared storage backend is switched to 'local' so MergeProcessor reads/writes real
-files via the file:// scheme; DuckDB's temp directory is redirected to a temp path.
+The shared storage backend is switched to 'local' so MergeProcessor (and the fixture
+helpers below) read/write real files via the file:// scheme; DuckDB's temp directory is
+redirected to a temp path. All DuckDB access goes through utils.execute_duckdb_sql — the
+project's connection helper — so no test opens a raw duckdb connection.
 """
 
-import os
-
-import duckdb
 import pytest
 
 import core.constants as constants
 import core.merge as merge
+import core.utils as utils
 from core.storage_backend import storage as shared_storage
-
-
-def _write_parquet(con, path: str, select_sql: str) -> None:
-    """Write a parquet file at a plain local path (creating parent dirs)."""
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    con.execute(f"COPY ({select_sql}) TO '{path}' (FORMAT parquet)")
 
 
 @pytest.fixture
@@ -40,23 +34,39 @@ def local_backend(tmp_path, monkeypatch):
     return tmp_path
 
 
+def _write_parquet(path: str, select_sql: str) -> None:
+    """
+    Write a parquet fixture via utils.execute_duckdb_sql.
+
+    The COPY target is a file:// uri so execute_duckdb_sql's local-backend hook
+    creates the parent directories automatically.
+    """
+    uri = shared_storage.get_uri(path)
+    utils.execute_duckdb_sql(
+        f"COPY ({select_sql}) TO '{uri}' (FORMAT parquet)",
+        f"Unable to write test fixture to {uri}",
+    )
+
+
+def _query(select_sql: str) -> list:
+    """Run a verification query through the helper and return all rows."""
+    return utils.execute_duckdb_sql(select_sql, "Verification query failed", return_results=True)
+
+
 def test_extract_all_then_reconcile_unions_rows_and_columns(local_backend):
     root = local_backend
-    con = duckdb.connect()
 
     # siteA: 2 rows, 3 columns
     site_a_src = str(root / "siteA/2025-01-01/artifacts/converted_files/measurement.parquet")
     _write_parquet(
-        con,
         site_a_src,
-        "SELECT * FROM (VALUES (1,'101','5.0'),(2,'102','6.0')) AS t(measurement_id, person_id, value)",
+        "SELECT * FROM (VALUES (1,101,'5.0'),(2,102,'6.0')) AS t(measurement_id, person_id, value)",
     )
     # siteB: 3 rows, with an EXTRA column to exercise union_by_name schema alignment
     site_b_src = str(root / "siteB/2025-02-01/artifacts/converted_files/measurement.parquet")
     _write_parquet(
-        con,
         site_b_src,
-        "SELECT * FROM (VALUES (10,'201','7.0','x'),(11,'202','8.0','y'),(12,'203','9.0','z')) "
+        "SELECT * FROM (VALUES (10,201,'7.0','x'),(11,202,'8.0','y'),(12,203,'9.0','z')) "
         "AS t(measurement_id, person_id, value, extra_col)",
     )
 
@@ -69,49 +79,43 @@ def test_extract_all_then_reconcile_unions_rows_and_columns(local_backend):
     merge.MergeProcessor.extract_chunk(site_b_src, chunk_b, constants.PARTICIPANT_SCOPE_ALL)
 
     # Provenance-named chunk files land in the shared per-table staging folder.
-    assert os.path.exists(chunk_a)
-    assert os.path.exists(chunk_b)
+    assert shared_storage.file_exists(chunk_a)
+    assert shared_storage.file_exists(chunk_b)
 
     merge.MergeProcessor.reconcile_chunks(str(chunk_dir / "*.parquet"), output)
-    assert os.path.exists(output)
+    assert shared_storage.file_exists(output)
 
-    verify = duckdb.connect()
-    row_count = verify.execute(f"SELECT count(*) FROM read_parquet('{output}')").fetchone()[0]
-    assert row_count == 5  # 2 (siteA) + 3 (siteB)
+    output_uri = shared_storage.get_uri(output)
+    merged_rows = _query(f"SELECT extra_col FROM read_parquet('{output_uri}')")
+    assert len(merged_rows) == 5  # 2 (siteA) + 3 (siteB)
 
-    columns = {r[0] for r in verify.execute(f"DESCRIBE SELECT * FROM read_parquet('{output}')").fetchall()}
+    columns = {r[0] for r in _query(f"DESCRIBE SELECT * FROM read_parquet('{output_uri}')")}
     assert {"measurement_id", "person_id", "value", "extra_col"} <= columns
 
     # siteA rows (no extra_col) are NULL-filled for the unioned column.
-    null_extra = verify.execute(
-        f"SELECT count(*) FROM read_parquet('{output}') WHERE extra_col IS NULL"
-    ).fetchone()[0]
+    null_extra = sum(1 for (extra_col,) in merged_rows if extra_col is None)
     assert null_extra == 2
 
 
 def test_extract_id_scope_subsets_participants(local_backend):
     root = local_backend
-    con = duckdb.connect()
 
     src = str(root / "siteA/2025-01-01/artifacts/converted_files/measurement.parquet")
     _write_parquet(
-        con,
         src,
-        "SELECT * FROM (VALUES (1,'101'),(2,'102'),(3,'103')) AS t(measurement_id, person_id)",
+        "SELECT * FROM (VALUES (1,101),(2,102),(3,103)) AS t(measurement_id, person_id)",
     )
-    # Keep only participants 101 and 103. The id column matches person_id's type (VARCHAR).
+    # Keep only participants 101 and 103. The id column is numeric, matching person_id.
     ids_uri = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/keep.parquet")
-    _write_parquet(con, ids_uri, "SELECT * FROM (VALUES ('101'),('103')) AS t(id)")
+    _write_parquet(ids_uri, "SELECT * FROM (VALUES (101),(103)) AS t(id)")
 
     chunk = str(root / "ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet")
 
     merge.MergeProcessor.extract_chunk(src, chunk, ids_uri)
 
-    verify = duckdb.connect()
+    chunk_uri = shared_storage.get_uri(chunk)
     kept = [
         r[0]
-        for r in verify.execute(
-            f"SELECT person_id FROM read_parquet('{chunk}') ORDER BY person_id"
-        ).fetchall()
+        for r in _query(f"SELECT person_id FROM read_parquet('{chunk_uri}') ORDER BY person_id")
     ]
-    assert kept == ['101', '103']
+    assert kept == [101, 103]

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -9,6 +9,7 @@ in tests/reference/sql/merge/
 from pathlib import Path
 
 from core.merge import MergeProcessor
+from core.merge_reporting import MergeReporter
 
 # Path to reference SQL files
 REFERENCE_DIR = Path(__file__).parent / "reference" / "sql" / "merge"
@@ -85,5 +86,27 @@ class TestReconcileGlobUnionByNameSql:
         )
 
         expected = load_reference_sql("reconcile_chunks_union_by_name.sql")
+        assert normalize_sql(result) == normalize_sql(expected)
+        assert "union_by_name=true" in result
+
+
+class TestMergeReportRowCountSql:
+    """Tests for MergeReporter row-count SQL + chunk-glob builders."""
+
+    def test_delivery_chunk_glob_matches_all_tables_for_one_delivery(self):
+        """The glob spans every per-table subfolder for a single (site, delivery_date)."""
+        glob = MergeReporter.delivery_chunk_glob(
+            merge_bucket="ehr_merged", run_date="2026-06-24", site="siteA", delivery_date="2025-01-01"
+        )
+        assert glob == "ehr_merged/2026-06-24/artifacts/merge_chunks/*/*__siteA__2025-01-01.parquet"
+
+    def test_row_count_globs_delivery_chunks_with_union_by_name(self):
+        """Counts one delivery's rows across all its per-table chunks via union_by_name."""
+        glob = MergeReporter.delivery_chunk_glob(
+            merge_bucket="ehr_merged", run_date="2026-06-24", site="siteA", delivery_date="2025-01-01"
+        )
+        result = MergeReporter.generate_delivery_row_count_sql(glob)
+
+        expected = load_reference_sql("merge_delivery_row_count.sql")
         assert normalize_sql(result) == normalize_sql(expected)
         assert "union_by_name=true" in result

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -35,36 +35,18 @@ def load_reference_sql(filename: str) -> str:
         return f.read()
 
 
-class TestExtractAllScopeSql:
-    """Tests for generate_extract_chunk_sql() with participant_scope == 'ALL'."""
+class TestExtractChunkSql:
+    """Tests for generate_extract_chunk_sql() — always copies the whole source table."""
 
-    def test_all_scope_has_no_where_clause(self):
-        """ALL scope copies the whole source table with no WHERE clause."""
+    def test_copies_whole_table_no_where_clause(self):
         result = MergeProcessor.generate_extract_chunk_sql(
             source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
             chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet",
-            participant_scope="ALL",
         )
 
         expected = load_reference_sql("extract_chunk_all_scope.sql")
         assert normalize_sql(result) == normalize_sql(expected)
         assert "WHERE" not in normalize_sql(result).upper()
-
-
-class TestExtractIdScopeSql:
-    """Tests for generate_extract_chunk_sql() with a participant-id subset (v2 path)."""
-
-    def test_id_scope_filters_by_person_id_in_subquery(self):
-        """A non-ALL scope subsets by person_id IN (SELECT id ...)."""
-        result = MergeProcessor.generate_extract_chunk_sql(
-            source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
-            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet",
-            participant_scope="ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/siteA__2025-01-01.parquet",
-        )
-
-        expected = load_reference_sql("extract_chunk_id_scope.sql")
-        assert normalize_sql(result) == normalize_sql(expected)
-        assert "WHERE person_id IN (" in result
 
 
 class TestReconcileGlobUnionByNameSql:
@@ -119,32 +101,19 @@ class TestHashCareSiteId:
 class TestExtractStampsCareSiteId:
     """Tests that a site name stamps care_site_id via SELECT * REPLACE."""
 
-    def test_all_scope_replaces_care_site_id_with_hash(self):
+    def test_site_name_replaces_care_site_id_with_hash(self):
         care_site_id = MergeProcessor.hash_care_site_id("Site A")
         result = MergeProcessor.generate_extract_chunk_sql(
             source_uri="siteA/2025-01-01/artifacts/converted_files/person.parquet",
             chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/person/person__siteA__2025-01-01.parquet",
-            participant_scope="ALL",
             site_display_name="Site A",
         )
         assert f"* REPLACE (CAST({care_site_id} AS BIGINT) AS care_site_id)" in result
-
-    def test_id_scope_replaces_care_site_id_with_hash(self):
-        care_site_id = MergeProcessor.hash_care_site_id("Site A")
-        result = MergeProcessor.generate_extract_chunk_sql(
-            source_uri="siteA/2025-01-01/artifacts/converted_files/person.parquet",
-            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet",
-            participant_scope="ehr_merged/ids.parquet",
-            site_display_name="Site A",
-        )
-        assert f"* REPLACE (CAST({care_site_id} AS BIGINT) AS care_site_id)" in result
-        assert "WHERE person_id IN (" in result
 
     def test_no_site_name_selects_star(self):
         result = MergeProcessor.generate_extract_chunk_sql(
             source_uri="siteA/2025-01-01/artifacts/converted_files/person.parquet",
             chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet",
-            participant_scope="ALL",
         )
         assert "REPLACE" not in result
         assert "SELECT * FROM read_parquet(" in normalize_sql(result)

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import core.constants as constants
 from core.merge import MergeProcessor
 from core.merge_reporting import MergeReporter
 
@@ -209,10 +210,10 @@ class TestBuildCdmSourceSql:
 
     def test_fixed_metadata_and_site_count(self):
         result = self._sql()
-        assert "'Connect for Cancer Prevention EHR Data' AS cdm_source_name" in result
-        assert "'Connect EHR' AS cdm_source_abbreviation" in result
-        assert "'NIH/NCI - Connect for Cancer Prevention Study' AS cdm_holder" in result
-        assert "Combined EHR data from 2 sites participating in the Connect for Cancer Prevention Study" in result
+        assert f"'{constants.MERGE_CDM_SOURCE_NAME}' AS cdm_source_name" in result
+        assert f"'{constants.MERGE_CDM_SOURCE_ABBREVIATION}' AS cdm_source_abbreviation" in result
+        assert f"'{constants.MERGE_CDM_HOLDER}' AS cdm_holder" in result
+        assert constants.MERGE_CDM_SOURCE_DESCRIPTION.format(site_count=2) in result
 
     def test_source_release_date_is_latest_across_sites(self):
         result = self._sql()

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -8,6 +8,8 @@ in tests/reference/sql/merge/
 
 from pathlib import Path
 
+import pytest
+
 from core.merge import MergeProcessor
 from core.merge_reporting import MergeReporter
 
@@ -110,3 +112,81 @@ class TestMergeReportRowCountSql:
         expected = load_reference_sql("merge_delivery_row_count.sql")
         assert normalize_sql(result) == normalize_sql(expected)
         assert "union_by_name=true" in result
+
+
+class TestHashCareSiteId:
+    """Tests for the site-name -> care_site_id hash."""
+
+    def test_deterministic_and_in_positive_signed_64_bit_range(self):
+        first = MergeProcessor.hash_care_site_id("Site A")
+        assert first == MergeProcessor.hash_care_site_id("Site A")
+        assert 1 <= first <= 0x7FFFFFFFFFFFFFFF
+
+    def test_distinct_names_give_distinct_ids(self):
+        assert MergeProcessor.hash_care_site_id("Site A") != MergeProcessor.hash_care_site_id("Site B")
+
+
+class TestExtractStampsCareSiteId:
+    """Tests that a site name stamps care_site_id via SELECT * REPLACE."""
+
+    def test_all_scope_replaces_care_site_id_with_hash(self):
+        care_site_id = MergeProcessor.hash_care_site_id("Site A")
+        result = MergeProcessor.generate_extract_chunk_sql(
+            source_uri="siteA/2025-01-01/artifacts/converted_files/person.parquet",
+            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/person/person__siteA__2025-01-01.parquet",
+            participant_scope="ALL",
+            site_display_name="Site A",
+        )
+        assert f"* REPLACE (CAST({care_site_id} AS BIGINT) AS care_site_id)" in result
+
+    def test_id_scope_replaces_care_site_id_with_hash(self):
+        care_site_id = MergeProcessor.hash_care_site_id("Site A")
+        result = MergeProcessor.generate_extract_chunk_sql(
+            source_uri="siteA/2025-01-01/artifacts/converted_files/person.parquet",
+            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet",
+            participant_scope="ehr_merged/ids.parquet",
+            site_display_name="Site A",
+        )
+        assert f"* REPLACE (CAST({care_site_id} AS BIGINT) AS care_site_id)" in result
+        assert "WHERE person_id IN (" in result
+
+    def test_no_site_name_selects_star(self):
+        result = MergeProcessor.generate_extract_chunk_sql(
+            source_uri="siteA/2025-01-01/artifacts/converted_files/person.parquet",
+            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/person/chunk.parquet",
+            participant_scope="ALL",
+        )
+        assert "REPLACE" not in result
+        assert "SELECT * FROM read_parquet(" in normalize_sql(result)
+
+
+class TestBuildCareSiteSql:
+    """Tests for generate_build_care_site_sql()."""
+
+    OUTPUT = "ehr_merged/2026-06-24/artifacts/converted_files/care_site.parquet"
+
+    def test_one_row_per_site_with_hashed_id_and_null_padding(self):
+        result = MergeProcessor.generate_build_care_site_sql(
+            self.OUTPUT, ["Site A", "Site B"], "5.4"
+        )
+        id_a = MergeProcessor.hash_care_site_id("Site A")
+        id_b = MergeProcessor.hash_care_site_id("Site B")
+        # schema order: care_site_id, care_site_name, then 4 unset columns
+        assert f"({id_a}, 'Site A', NULL, NULL, NULL, NULL)" in result
+        assert f"({id_b}, 'Site B', NULL, NULL, NULL, NULL)" in result
+        # projection/types come from the OMOP care_site schema
+        assert "CAST(care_site_id AS BIGINT) AS care_site_id" in result
+        assert "CAST(care_site_name AS VARCHAR) AS care_site_name" in result
+
+    def test_escapes_single_quotes_in_name(self):
+        result = MergeProcessor.generate_build_care_site_sql(self.OUTPUT, ["O'Neil Clinic"], "5.4")
+        assert "'O''Neil Clinic'" in result
+
+    def test_dedups_repeated_site_names(self):
+        result = MergeProcessor.generate_build_care_site_sql(self.OUTPUT, ["Site A", "Site A"], "5.4")
+        id_a = MergeProcessor.hash_care_site_id("Site A")
+        assert result.count(f"({id_a}, 'Site A'") == 1
+
+    def test_empty_site_list_raises(self):
+        with pytest.raises(ValueError):
+            MergeProcessor.generate_build_care_site_sql(self.OUTPUT, [], "5.4")

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for merge.py SQL generation functions.
+
+Tests that SQL generation functions produce output matching reference SQL files.
+Reference SQL files were captured from known-good function output and are stored
+in tests/reference/sql/merge/
+"""
+
+from pathlib import Path
+
+from core.merge import MergeProcessor
+
+# Path to reference SQL files
+REFERENCE_DIR = Path(__file__).parent / "reference" / "sql" / "merge"
+
+
+def normalize_sql(sql: str) -> str:
+    """
+    Normalize SQL for comparison by removing extra whitespace.
+    Makes SQL comparison whitespace-insensitive.
+    """
+    lines = [line.strip() for line in sql.strip().split('\n')]
+    lines = [line for line in lines if line]
+    return '\n'.join(lines)
+
+
+def load_reference_sql(filename: str) -> str:
+    """Load reference SQL from file."""
+    filepath = REFERENCE_DIR / filename
+    with open(filepath, 'r') as f:
+        return f.read()
+
+
+class TestExtractAllScopeSql:
+    """Tests for generate_extract_chunk_sql() with participant_scope == 'ALL'."""
+
+    def test_all_scope_has_no_where_clause(self):
+        """ALL scope copies the whole source table with no WHERE clause."""
+        result = MergeProcessor.generate_extract_chunk_sql(
+            source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
+            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet",
+            participant_scope="ALL",
+        )
+
+        expected = load_reference_sql("extract_chunk_all_scope.sql")
+        assert normalize_sql(result) == normalize_sql(expected)
+        assert "WHERE" not in normalize_sql(result).upper()
+
+
+class TestExtractIdScopeSql:
+    """Tests for generate_extract_chunk_sql() with a participant-id subset (v2 path)."""
+
+    def test_id_scope_uses_try_cast_in_subquery(self):
+        """A non-ALL scope subsets by TRY_CAST(person_id AS BIGINT) IN (SELECT id ...)."""
+        result = MergeProcessor.generate_extract_chunk_sql(
+            source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
+            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet",
+            participant_scope="ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/siteA__2025-01-01.parquet",
+            person_id_column="person_id",
+        )
+
+        expected = load_reference_sql("extract_chunk_id_scope.sql")
+        assert normalize_sql(result) == normalize_sql(expected)
+
+    def test_id_scope_respects_custom_person_id_column(self):
+        """A custom person_id column name is used in the TRY_CAST."""
+        result = MergeProcessor.generate_extract_chunk_sql(
+            source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
+            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet",
+            participant_scope="ehr_merged/ids.parquet",
+            person_id_column="subject_id",
+        )
+
+        assert "TRY_CAST(subject_id AS BIGINT)" in result
+
+
+class TestReconcileGlobUnionByNameSql:
+    """Tests for generate_reconcile_chunks_sql()."""
+
+    def test_reconcile_globs_chunks_with_union_by_name(self):
+        """Reconcile reads a glob of chunks with union_by_name and writes one output."""
+        result = MergeProcessor.generate_reconcile_chunks_sql(
+            chunk_glob="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/*.parquet",
+            output_uri="ehr_merged/2026-06-24/artifacts/converted_files/measurement.parquet",
+        )
+
+        expected = load_reference_sql("reconcile_chunks_union_by_name.sql")
+        assert normalize_sql(result) == normalize_sql(expected)
+        assert "union_by_name=true" in result

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -190,3 +190,48 @@ class TestBuildCareSiteSql:
     def test_empty_site_list_raises(self):
         with pytest.raises(ValueError):
             MergeProcessor.generate_build_care_site_sql(self.OUTPUT, [], "5.4")
+
+
+class TestBuildCdmSourceSql:
+    """Tests for generate_build_cdm_source_sql()."""
+
+    OUTPUT = "ehr_merged/2026-06-24/artifacts/converted_files/cdm_source.parquet"
+    SOURCES = [
+        "siteA/2025-01-01/artifacts/converted_files/cdm_source.parquet",
+        "siteB/2025-02-01/artifacts/converted_files/cdm_source.parquet",
+    ]
+
+    def _sql(self, cdm_version="5.4"):
+        return MergeProcessor.generate_build_cdm_source_sql(
+            self.OUTPUT, self.SOURCES, site_count=2, cdm_version=cdm_version,
+            vocabulary_version="v5.0 27-AUG-25", cdm_release_date="2026-06-24",
+        )
+
+    def test_fixed_metadata_and_site_count(self):
+        result = self._sql()
+        assert "'Connect for Cancer Prevention EHR Data' AS cdm_source_name" in result
+        assert "'Connect EHR' AS cdm_source_abbreviation" in result
+        assert "'NIH/NCI - Connect for Cancer Prevention Study' AS cdm_holder" in result
+        assert "Combined EHR data from 2 sites participating in the Connect for Cancer Prevention Study" in result
+
+    def test_source_release_date_is_latest_across_sites(self):
+        result = self._sql()
+        assert "MAX(source_release_date)" in result
+        # union over both sites' cdm_source files
+        assert "read_parquet([" in result and "union_by_name=true" in result
+        for uri in self.SOURCES:
+            assert uri in result
+
+    def test_release_date_versions_and_concept_id(self):
+        result = self._sql(cdm_version="5.4")
+        assert "CAST('2026-06-24' AS DATE) AS cdm_release_date" in result
+        assert "'5.4' AS cdm_version" in result
+        assert "756265 AS cdm_version_concept_id" in result  # 5.4 concept id
+        assert "'v5.0 27-AUG-25' AS vocabulary_version" in result
+
+    def test_empty_sources_raises(self):
+        with pytest.raises(ValueError):
+            MergeProcessor.generate_build_cdm_source_sql(
+                self.OUTPUT, [], site_count=0, cdm_version="5.4",
+                vocabulary_version="v", cdm_release_date="2026-06-24",
+            )

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -50,8 +50,8 @@ class TestExtractAllScopeSql:
 class TestExtractIdScopeSql:
     """Tests for generate_extract_chunk_sql() with a participant-id subset (v2 path)."""
 
-    def test_id_scope_uses_try_cast_in_subquery(self):
-        """A non-ALL scope subsets by TRY_CAST(person_id AS BIGINT) IN (SELECT id ...)."""
+    def test_id_scope_filters_by_person_id_in_subquery(self):
+        """A non-ALL scope subsets by person_id IN (SELECT id ...)."""
         result = MergeProcessor.generate_extract_chunk_sql(
             source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
             chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet",
@@ -63,7 +63,7 @@ class TestExtractIdScopeSql:
         assert normalize_sql(result) == normalize_sql(expected)
 
     def test_id_scope_respects_custom_person_id_column(self):
-        """A custom person_id column name is used in the TRY_CAST."""
+        """A custom person_id column name is used in the WHERE clause."""
         result = MergeProcessor.generate_extract_chunk_sql(
             source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
             chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet",
@@ -71,7 +71,7 @@ class TestExtractIdScopeSql:
             person_id_column="subject_id",
         )
 
-        assert "TRY_CAST(subject_id AS BIGINT)" in result
+        assert "WHERE subject_id IN (" in result
 
 
 class TestReconcileGlobUnionByNameSql:

--- a/tests/test_merge_sql.py
+++ b/tests/test_merge_sql.py
@@ -60,22 +60,11 @@ class TestExtractIdScopeSql:
             source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
             chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/measurement__siteA__2025-01-01.parquet",
             participant_scope="ehr_merged/2026-06-24/artifacts/merge_chunks/_ids/siteA__2025-01-01.parquet",
-            person_id_column="person_id",
         )
 
         expected = load_reference_sql("extract_chunk_id_scope.sql")
         assert normalize_sql(result) == normalize_sql(expected)
-
-    def test_id_scope_respects_custom_person_id_column(self):
-        """A custom person_id column name is used in the WHERE clause."""
-        result = MergeProcessor.generate_extract_chunk_sql(
-            source_uri="siteA/2025-01-01/artifacts/converted_files/measurement.parquet",
-            chunk_uri="ehr_merged/2026-06-24/artifacts/merge_chunks/measurement/chunk.parquet",
-            participant_scope="ehr_merged/ids.parquet",
-            person_id_column="subject_id",
-        )
-
-        assert "WHERE subject_id IN (" in result
+        assert "WHERE person_id IN (" in result
 
 
 class TestReconcileGlobUnionByNameSql:

--- a/tests/test_omop_client.py
+++ b/tests/test_omop_client.py
@@ -199,7 +199,7 @@ class TestOMOPClientPopulateCdmSourceFile:
     @patch('core.omop_client.utils.execute_duckdb_sql')
     @patch('core.omop_client.utils.parquet_file_exists')
     def test_populate_cdm_source_file_one_row_always_rewrites_release_dates(self, mock_file_exists, mock_execute, mock_artifact):
-        """File has 1 row -> always rewrite source_release_date (COALESCE/fallback) and cdm_release_date (=delivery_date), preserving every other site value."""
+        """File has 1 row -> rewrite source_release_date and cdm_release_date (both COALESCE: keep site value, fallback delivery_date), preserving every other site value."""
         mock_file_exists.return_value = True
         mock_execute.side_effect = [
             [[1]],    # row count

--- a/tests/test_omop_client.py
+++ b/tests/test_omop_client.py
@@ -361,3 +361,30 @@ class TestOMOPClientStaticMethods:
 
         expected = load_reference_sql("generate_populate_cdm_source_sql_simple.sql")
         assert normalize_sql(sql) == normalize_sql(expected)
+
+
+class TestGetDeliveryCdmVersion:
+    """Tests for get_delivery_cdm_version() reader (DuckDB mocked)."""
+
+    @patch('core.omop_client.utils.execute_duckdb_sql')
+    def test_returns_versions_from_cdm_source(self, mock_execute):
+        """Reads cdm_version and vocabulary_version from the delivery's cdm_source parquet."""
+        mock_execute.return_value = [("5.4", "v5.0 27-AUG-25")]
+
+        result = OMOPClient.get_delivery_cdm_version("siteA", "2025-01-01")
+
+        assert result == {"cdm_version": "5.4", "vocabulary_version": "v5.0 27-AUG-25"}
+
+        # Reads from the delivery's converted_files/cdm_source.parquet with return_results=True.
+        sql_arg = mock_execute.call_args[0][0]
+        assert "siteA/2025-01-01/artifacts/converted_files/cdm_source.parquet" in sql_arg
+        assert mock_execute.call_args.kwargs.get("return_results") is True
+
+    @patch('core.omop_client.utils.execute_duckdb_sql')
+    def test_returns_none_when_cdm_source_empty(self, mock_execute):
+        """An empty cdm_source (no rows) yields None versions rather than raising."""
+        mock_execute.return_value = []
+
+        result = OMOPClient.get_delivery_cdm_version("siteA", "2025-01-01")
+
+        assert result == {"cdm_version": None, "vocabulary_version": None}

--- a/tests/test_omop_client_sql.py
+++ b/tests/test_omop_client_sql.py
@@ -236,3 +236,16 @@ class TestGenerateRewriteReleaseDatesSql:
 
         expected = load_reference_sql("generate_rewrite_release_dates_sql_standard.sql")
         assert normalize_sql(result) == normalize_sql(expected)
+
+
+class TestGenerateGetDeliveryCdmVersionSql:
+    """Tests for generate_get_delivery_cdm_version_sql()."""
+
+    def test_standard(self):
+        """SQL reads cdm_version and vocabulary_version from a cdm_source parquet, limit 1."""
+        result = OMOPClient.generate_get_delivery_cdm_version_sql(
+            "gs://siteA/2025-01-01/artifacts/converted_files/cdm_source.parquet"
+        )
+
+        expected = load_reference_sql("generate_get_delivery_cdm_version_sql_standard.sql")
+        assert normalize_sql(result) == normalize_sql(expected)

--- a/tests/test_omop_client_sql.py
+++ b/tests/test_omop_client_sql.py
@@ -223,19 +223,25 @@ class TestGenerateSourceExtractionDateSql:
         assert normalize_sql(result) == normalize_sql(expected)
 
 
-class TestGenerateRewriteReleaseDatesSql:
-    """Tests for generate_rewrite_release_dates_sql()."""
+class TestGenerateRewriteCdmSourceSql:
+    """Tests for generate_rewrite_cdm_source_sql()."""
 
     def test_standard_rewrite_sql(self):
-        """SQL uses SELECT * REPLACE to rewrite source_release_date (COALESCE/fallback) and cdm_release_date (=delivery_date), preserving every other column."""
+        """SQL uses SELECT * REPLACE to overwrite release dates + cdm/vocab versions to target, preserving every other column."""
         cdm_source_uri = "gs://test-bucket/2025-01-15/artifacts/converted_files/cdm_source.parquet"
         date_format = "%Y-%m-%d"
         delivery_date = "2025-01-15"
 
-        result = OMOPClient.generate_rewrite_release_dates_sql(cdm_source_uri, date_format, delivery_date)
+        result = OMOPClient.generate_rewrite_cdm_source_sql(
+            cdm_source_uri, date_format, delivery_date, "5.4", "v5.0 27-AUG-25"
+        )
 
-        expected = load_reference_sql("generate_rewrite_release_dates_sql_standard.sql")
+        expected = load_reference_sql("generate_rewrite_cdm_source_sql_standard.sql")
         assert normalize_sql(result) == normalize_sql(expected)
+        # Target versions overwrite whatever the site delivered.
+        assert "'5.4' AS cdm_version" in result
+        assert "756265 AS cdm_version_concept_id" in result
+        assert "'v5.0 27-AUG-25' AS vocabulary_version" in result
 
 
 class TestGenerateGetDeliveryCdmVersionSql:

--- a/tests/test_pipeline_log.py
+++ b/tests/test_pipeline_log.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for pipeline_log.get_latest_completed_delivery().
+
+BigQuery is mocked; these tests assert the query shape (status filter, ordering,
+limit) and the None-return behavior when nothing is completed or the table is absent.
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from google.cloud.exceptions import NotFound
+
+import core.constants as constants
+import core.helpers.pipeline_log as pipeline_log
+
+
+def _make_client(rows=None, table_exists=True):
+    """Build a mocked bigquery.Client whose query() returns the given rows."""
+    mock_client = MagicMock()
+
+    if table_exists:
+        mock_client.get_table.return_value = MagicMock()
+    else:
+        mock_client.get_table.side_effect = NotFound("table not found")
+
+    mock_query_job = MagicMock()
+    mock_query_job.result.return_value = rows if rows is not None else []
+    mock_client.query.return_value = mock_query_job
+
+    return mock_client
+
+
+class TestGetLatestCompletedDelivery:
+    """Tests for the happy-path query."""
+
+    @patch('core.helpers.pipeline_log.bigquery.Client')
+    def test_returns_latest_completed_date(self, mock_client_cls):
+        mock_client = _make_client(rows=[{"delivery_date": date(2025, 3, 1)}])
+        mock_client_cls.return_value = mock_client
+
+        result = pipeline_log.get_latest_completed_delivery("siteA")
+
+        assert result == "2025-03-01"
+
+    @patch('core.helpers.pipeline_log.bigquery.Client')
+    def test_query_filters_by_completed_status_ordered_desc_limit_one(self, mock_client_cls):
+        mock_client = _make_client(rows=[{"delivery_date": date(2025, 3, 1)}])
+        mock_client_cls.return_value = mock_client
+
+        pipeline_log.get_latest_completed_delivery("siteA")
+
+        query_text = mock_client.query.call_args[0][0]
+        assert "status = @status" in query_text
+        assert "ORDER BY delivery_date DESC" in query_text
+        assert "LIMIT 1" in query_text
+
+        # The status parameter binds to the 'completed' status constant.
+        job_config = mock_client.query.call_args[1]["job_config"]
+        status_params = [p for p in job_config.query_parameters if p.name == "status"]
+        assert status_params and status_params[0].value == constants.PIPELINE_COMPLETE_STRING
+
+    @patch('core.helpers.pipeline_log.bigquery.Client')
+    def test_string_delivery_date_passthrough(self, mock_client_cls):
+        """A delivery_date already returned as a string is passed through unchanged."""
+        mock_client = _make_client(rows=[{"delivery_date": "2024-12-31"}])
+        mock_client_cls.return_value = mock_client
+
+        assert pipeline_log.get_latest_completed_delivery("siteA") == "2024-12-31"
+
+
+class TestGetLatestCompletedNoCompleted:
+    """Tests for the no-result and missing-table cases."""
+
+    @patch('core.helpers.pipeline_log.bigquery.Client')
+    def test_no_completed_delivery_returns_none(self, mock_client_cls):
+        mock_client = _make_client(rows=[])
+        mock_client_cls.return_value = mock_client
+
+        assert pipeline_log.get_latest_completed_delivery("siteA") is None
+
+    @patch('core.helpers.pipeline_log.bigquery.Client')
+    def test_missing_logging_table_returns_none_without_query(self, mock_client_cls):
+        mock_client = _make_client(table_exists=False)
+        mock_client_cls.return_value = mock_client
+
+        assert pipeline_log.get_latest_completed_delivery("siteA") is None
+        mock_client.query.assert_not_called()


### PR DESCRIPTION
Add file processor endpoints, Cloud Run jobs, and helpers that combine every site's latest `completed` OMOP delivery into a single merged OMOP instance. This is "v1" of the EHR PR2 pipeline functionality which does **not** "look back" to retrieve data for participants who have withdrawn but have not requested data deletion. In this version, these participants are filtered out of the dataset using existing filtering functionality.

- Add `/extract_participant_chunk` endpoint and matching `ccc-omop-file-processor-extract-participant-chunk-job` Cloud Run job that copy one source-delivery table into a provenance-named chunk file (`<table>__<site>__<delivery_date>.parquet`) in a new `artifacts/merge_chunks/` staging area
- Add `/reconcile_chunks` endpoint and matching `ccc-omop-file-processor-reconcile-chunks-job` Cloud Run job that union a table's chunks into a single merged `converted_files/<table>.parquet`
- Add `core/merge.py` (`MergeProcessor`) housing the extract, reconcile, and build SQL generators/executors
- Stamp `person.care_site_id` with a deterministic hash of the source site's display name during extract, so each merged patient records which site it came from
- Add `/build_care_site` endpoint that writes a `care_site` table mapping each merged site's hashed `care_site_id` to its name; `care_site` rows are NOT carried over from the individual deliveries
- Add `/build_merge_cdm_source` endpoint that writes a one-row `cdm_source` for the merged instance
- Change the single-site `/populate_cdm_source_file` one-row path to overwrite `cdm_version`, `cdm_version_concept_id`, and `vocabulary_version` with the target values the pipeline standardized to
- Add `/get_latest_completed_delivery` endpoint that returns a site's most recent `completed` delivery date via a server-side BigQuery query
- Add `/get_delivery_cdm_version` endpoint that reads the CDM and vocabulary version a processed delivery was standardized to from its `converted_files/cdm_source.parquet`
- Add `/generate_merge_report` endpoint and `core/merge_reporting.py` (`MergeReporter`) that record which sites and `(site, delivery_date)` deliveries were merged and the row count each contributed
- Add tests (`test_merge_sql.py`, `test_extract_reconcile_e2e.py`, `test_pipeline_log.py`) and extend the endpoint and `omop_client` test suites